### PR TITLE
arb-reth: Arbitrum integration scaffolding (Nitro parity) — hooks, predeploys, primitives, Docker, tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/paradigmxyz/reth"
 exclude = [".github/"]
 
 [workspace]
+
+[workspace.dependencies]
+revm-precompile = "25.0.0"
 members = [
     "bin/reth-bench/",
     "bin/reth/",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ repository = "https://github.com/paradigmxyz/reth"
 exclude = [".github/"]
 
 [workspace]
-
-[workspace.dependencies]
-revm-precompile = "25.0.0"
 members = [
     "bin/reth-bench/",
     "bin/reth/",
@@ -333,6 +330,7 @@ lto = "fat"
 codegen-units = 1
 
 [workspace.dependencies]
+revm-precompile = "25.0.0"
 # reth
 op-reth = { path = "crates/optimism/bin" }
 reth = { path = "bin/reth" }
@@ -745,5 +743,3 @@ vergen-git2 = "1.0.5"
 # alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
-[patch.crates-io]
-revm-precompile = "=25.0.0"

--- a/crates/arbitrum/bin/Dockerfile
+++ b/crates/arbitrum/bin/Dockerfile
@@ -1,12 +1,14 @@
 # syntax=docker/dockerfile:1
 
-FROM rust:1.78 as builder
+FROM rust:1.81 as builder
 WORKDIR /build
 # Install git to fetch external workspace deps
-RUN apt-get update && apt-get install -y git ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git ca-certificates clang libclang-dev llvm-dev pkg-config build-essential && rm -rf /var/lib/apt/lists/*
 # Clone arb-alloy into the expected path inside the container (reth expects /arb-alloy/*)
 RUN git clone https://github.com/tiljrd/arb-alloy /arb-alloy --depth 1
 COPY . /build
+RUN rustup toolchain install nightly && rustup default nightly
+
 RUN cargo build --release -p arb-reth
 
 FROM debian:bookworm-slim

--- a/crates/arbitrum/evm/src/build.rs
+++ b/crates/arbitrum/evm/src/build.rs
@@ -95,12 +95,16 @@ where
         let calldata_len = calldata.len();
         let gas_limit = tx.tx().gas_limit();
 
+        let block_env = self.evm().block();
+        let block_basefee = block_env.basefee;
+        let block_coinbase = block_env.beneficiary;
+
         let start_ctx = ArbStartTxContext {
             sender,
             nonce,
-            l1_base_fee: U256::ZERO,
+            l1_base_fee: block_basefee,
             calldata_len,
-            coinbase: Address::ZERO,
+            coinbase: block_coinbase,
             executed_on_chain: true,
             is_eth_call: false,
         };
@@ -109,7 +113,7 @@ where
         let gas_ctx = ArbGasChargingContext {
             intrinsic_gas: 21_000,
             calldata,
-            basefee: U256::ZERO,
+            basefee: block_basefee,
             is_executed_on_chain: true,
             skip_l1_charging: false,
         };
@@ -121,7 +125,7 @@ where
             success: res.is_ok(),
             gas_left: 0,
             gas_limit,
-            basefee: U256::ZERO,
+            basefee: block_basefee,
         };
         self.hooks.end_tx(self.evm_mut(), &mut self.tx_state, &end_ctx);
 

--- a/crates/arbitrum/evm/src/build.rs
+++ b/crates/arbitrum/evm/src/build.rs
@@ -190,6 +190,7 @@ impl EvmFactory for ArbEvmFactory {
                     origin: ctx.env.tx().caller(),
                     caller: ctx.env.tx().caller(),
                     depth: ctx.depth as u64,
+                    basefee: block.basefee,
                 };
                 let bytes = Bytes::copy_from_slice(input);
                 let (ret, gas_left, success) =

--- a/crates/arbitrum/evm/src/lib.rs
+++ b/crates/arbitrum/evm/src/lib.rs
@@ -317,7 +317,7 @@ mod tests {
     fn default_predeploy_registry_dispatches_known_address() {
         use alloy_primitives::address;
         let cfg = ArbEvmConfig::<(), (), ArbRethReceiptBuilder>::default();
-        let reg = cfg.default_predeploy_registry();
+        let mut reg = cfg.default_predeploy_registry();
         let sys = address!("0000000000000000000000000000000000000064");
         let ctx = crate::predeploys::PredeployCallContext {
             block_number: 100,

--- a/crates/arbitrum/evm/src/lib.rs
+++ b/crates/arbitrum/evm/src/lib.rs
@@ -494,6 +494,114 @@ mod tests {
         let signer = signed.try_recover().expect("recover");
         assert_eq!(signer, address!("00000000000000000000000000000000000000aa"));
     }
+    #[test]
+    fn arb_tx_iterator_recovers_signer_for_contract() {
+        use arb_alloy_consensus::tx::ArbContractTx;
+        use alloy_primitives::{address, Bytes, U256, B256};
+
+        let env = arb_alloy_consensus::ArbTxEnvelope::Contract(ArbContractTx {
+            chain_id: U256::from(42161u64),
+            request_id: B256::from([0x22u8; 32]),
+            from: address!("00000000000000000000000000000000000000ab"),
+            gas_fee_cap: U256::from(1000u64),
+            gas: 21000,
+            to: None,
+            value: U256::ZERO,
+            data: Vec::new(),
+        });
+        let enc = env.encode_typed();
+        let payload = reth_arbitrum_payload::ArbExecutionData {
+            payload: reth_arbitrum_payload::ArbPayload {
+                v1: reth_arbitrum_payload::ArbPayloadV1 {
+                    transactions: vec![Bytes::from(enc)],
+                    ..Default::default()
+                },
+            },
+            ..Default::default()
+        };
+        let cfg = ArbEvmConfig::<(), (), ArbRethReceiptBuilder>::default();
+        let mut it = cfg.tx_iterator_for_payload(&payload);
+        let item = it.next().expect("one").expect("ok");
+        let signed = item.inner();
+        let signer = signed.try_recover().expect("recover");
+        assert_eq!(signer, address!("00000000000000000000000000000000000000ab"));
+    }
+
+    #[test]
+    fn arb_tx_iterator_recovers_signer_for_retry() {
+        use arb_alloy_consensus::tx::ArbRetryTx;
+        use alloy_primitives::{address, Bytes, U256, B256};
+
+        let env = arb_alloy_consensus::ArbTxEnvelope::Retry(ArbRetryTx {
+            chain_id: U256::from(42161u64),
+            nonce: 1,
+            from: address!("00000000000000000000000000000000000000ac"),
+            gas_fee_cap: U256::from(1000u64),
+            gas: 21000,
+            to: None,
+            value: U256::ZERO,
+            data: Vec::new(),
+            ticket_id: B256::from([0x33u8; 32]),
+            refund_to: address!("00000000000000000000000000000000000000ff"),
+            max_refund: U256::ZERO,
+            submission_fee_refund: U256::ZERO,
+        });
+        let enc = env.encode_typed();
+        let payload = reth_arbitrum_payload::ArbExecutionData {
+            payload: reth_arbitrum_payload::ArbPayload {
+                v1: reth_arbitrum_payload::ArbPayloadV1 {
+                    transactions: vec![Bytes::from(enc)],
+                    ..Default::default()
+                },
+            },
+            ..Default::default()
+        };
+        let cfg = ArbEvmConfig::<(), (), ArbRethReceiptBuilder>::default();
+        let mut it = cfg.tx_iterator_for_payload(&payload);
+        let item = it.next().expect("one").expect("ok");
+        let signed = item.inner();
+        let signer = signed.try_recover().expect("recover");
+        assert_eq!(signer, address!("00000000000000000000000000000000000000ac"));
+    }
+
+    #[test]
+    fn arb_tx_iterator_recovers_signer_for_submit_retryable() {
+        use arb_alloy_consensus::tx::ArbSubmitRetryableTx;
+        use alloy_primitives::{address, Bytes, U256, B256};
+
+        let env = arb_alloy_consensus::ArbTxEnvelope::SubmitRetryable(ArbSubmitRetryableTx {
+            chain_id: U256::from(42161u64),
+            request_id: B256::from([0x44u8; 32]),
+            from: address!("00000000000000000000000000000000000000ad"),
+            l1_base_fee: U256::from(1u64),
+            deposit_value: U256::from(2u64),
+            gas_fee_cap: U256::from(3u64),
+            gas: 21000,
+            retry_to: None,
+            retry_value: U256::ZERO,
+            beneficiary: address!("00000000000000000000000000000000000000ee"),
+            max_submission_fee: U256::from(4u64),
+            fee_refund_addr: address!("00000000000000000000000000000000000000dd"),
+            retry_data: Vec::new(),
+        });
+        let enc = env.encode_typed();
+        let payload = reth_arbitrum_payload::ArbExecutionData {
+            payload: reth_arbitrum_payload::ArbPayload {
+                v1: reth_arbitrum_payload::ArbPayloadV1 {
+                    transactions: vec![Bytes::from(enc)],
+                    ..Default::default()
+                },
+            },
+            ..Default::default()
+        };
+        let cfg = ArbEvmConfig::<(), (), ArbRethReceiptBuilder>::default();
+        let mut it = cfg.tx_iterator_for_payload(&payload);
+        let item = it.next().expect("one").expect("ok");
+        let signed = item.inner();
+        let signer = signed.try_recover().expect("recover");
+        assert_eq!(signer, address!("00000000000000000000000000000000000000ad"));
+    }
+
 
 }
 

--- a/crates/arbitrum/evm/src/predeploys.rs
+++ b/crates/arbitrum/evm/src/predeploys.rs
@@ -265,7 +265,15 @@ impl PredeployHandler for ArbRetryableTx {
                 let _ = retryables.keepalive_retryable(&crate::retryables::RetryableTicketId(tid));
                 (abi_zero_word(), gas_limit, true)
             }
-            s if s == get_beneficiary => (abi_zero_word(), gas_limit, true),
+            s if s == get_beneficiary => {
+                let tid = read_ticket_id(input);
+                let addr = retryables
+                    .get_beneficiary(&crate::retryables::RetryableTicketId(tid))
+                    .unwrap_or(Address::ZERO);
+                let mut out = [0u8; 32];
+                out[12..].copy_from_slice(addr.as_slice());
+                (Bytes::from(out.to_vec()), gas_limit, true)
+            },
             s if s == get_current_redeemer => (abi_zero_word(), gas_limit, true),
             s if s == submit_retryable => {
                 let params = crate::retryables::RetryableCreateParams {

--- a/crates/arbitrum/evm/src/predeploys.rs
+++ b/crates/arbitrum/evm/src/predeploys.rs
@@ -871,6 +871,26 @@ mod tests {
         let (out, _gas, success) = call(pre::selector(pre::SIG_RETRY_SUBMIT_RETRYABLE));
         assert!(success);
         assert_eq!(out.len(), 32);
+    #[test]
+    fn arb_retryable_tx_submit_returns_ticket_id_word() {
+        use alloy_primitives::address;
+        use arb_alloy_predeploys as pre;
+
+        let mut reg = PredeployRegistry::with_default_addresses();
+        let addr_retry = address!("000000000000000000000000000000000000006e");
+
+        let mut input = alloc::vec::Vec::with_capacity(4);
+        input.extend_from_slice(&pre::selector(pre::SIG_RETRY_SUBMIT_RETRYABLE));
+        let (out, _gas, success) = reg
+            .dispatch(&mk_ctx(), addr_retry, &Bytes::from(input), 50_000, U256::ZERO)
+            .expect("dispatch");
+        assert!(success);
+        assert_eq!(out.len(), 32);
+        let mut buf = [0u8; 32];
+        buf.copy_from_slice(&out[..32]);
+        assert_ne!(buf, [0u8; 32]);
+    }
+
     }
 
     #[test]

--- a/crates/arbitrum/evm/src/predeploys.rs
+++ b/crates/arbitrum/evm/src/predeploys.rs
@@ -868,8 +868,9 @@ mod tests {
         let _ = call(pre::selector(pre::SIG_RETRY_KEEPALIVE));
         let _ = call(pre::selector(pre::SIG_RETRY_GET_BENEFICIARY));
         let _ = call(pre::selector(pre::SIG_RETRY_GET_CURRENT_REDEEMER));
-        let (_out, _gas, success) = call(pre::selector(pre::SIG_RETRY_SUBMIT_RETRYABLE));
-        assert!(!success);
+        let (out, _gas, success) = call(pre::selector(pre::SIG_RETRY_SUBMIT_RETRYABLE));
+        assert!(success);
+        assert_eq!(out.len(), 32);
     }
 
     #[test]

--- a/crates/arbitrum/evm/src/predeploys.rs
+++ b/crates/arbitrum/evm/src/predeploys.rs
@@ -232,7 +232,7 @@ impl PredeployHandler for ArbRetryableTx {
             s if s == keepalive => (abi_zero_word(), gas_limit, true),
             s if s == get_beneficiary => (abi_zero_word(), gas_limit, true),
             s if s == get_current_redeemer => (abi_zero_word(), gas_limit, true),
-            s if s == submit_retryable => (Bytes::default(), gas_limit, false),
+            s if s == submit_retryable => (abi_zero_word(), gas_limit, false),
             _ => (Bytes::default(), gas_limit, true),
         }
 }

--- a/crates/arbitrum/evm/src/predeploys.rs
+++ b/crates/arbitrum/evm/src/predeploys.rs
@@ -175,8 +175,9 @@ impl PredeployHandler for ArbSys {
                     gas_price_bid: U256::ZERO,
                 };
                 match retryables.create_retryable(params) {
-                    crate::retryables::RetryableAction::Created { .. } => {
-                        let out = [0u8; 32];
+                    crate::retryables::RetryableAction::Created { ticket_id, .. } => {
+                        let mut out = [0u8; 32];
+                        out.copy_from_slice(&ticket_id.0);
                         (Bytes::from(out.to_vec()), gas_limit, true)
                     }
                     _ => (Bytes::default(), gas_limit, false),
@@ -274,7 +275,11 @@ impl PredeployHandler for ArbRetryableTx {
                 out[12..].copy_from_slice(addr.as_slice());
                 (Bytes::from(out.to_vec()), gas_limit, true)
             },
-            s if s == get_current_redeemer => (abi_zero_word(), gas_limit, true),
+            s if s == get_current_redeemer => {
+                let mut out = [0u8; 32];
+                out[12..].copy_from_slice(ctx.caller.as_slice());
+                (Bytes::from(out.to_vec()), gas_limit, true)
+            },
             s if s == submit_retryable => {
                 let params = crate::retryables::RetryableCreateParams {
                     sender: Address::ZERO,

--- a/crates/arbitrum/evm/src/predeploys.rs
+++ b/crates/arbitrum/evm/src/predeploys.rs
@@ -372,7 +372,7 @@ impl PredeployHandler for ArbOwner {
         self.addr
     }
 
-    fn call(&self, _ctx: &PredeployCallContext, input: &Bytes, gas_limit: u64, _value: U256, _retryables: &mut dyn Retryables) -> (Bytes, u64, bool) {
+    fn call(&self, _ctx: &PredeployCallContext, input: &Bytes, gas_limit: u64, _value: U256, retryables: &mut dyn Retryables) -> (Bytes, u64, bool) {
         use arb_alloy_predeploys as pre;
         let sel = input.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]).unwrap_or([0u8; 4]);
 
@@ -424,7 +424,7 @@ impl PredeployHandler for ArbGasInfo {
         self.addr
     }
 
-    fn call(&self, _ctx: &PredeployCallContext, input: &Bytes, gas_limit: u64, _value: U256, _retryables: &mut dyn Retryables) -> (Bytes, u64, bool) {
+    fn call(&self, _ctx: &PredeployCallContext, input: &Bytes, gas_limit: u64, _value: U256, retryables: &mut dyn Retryables) -> (Bytes, u64, bool) {
         use arb_alloy_predeploys as pre;
         let sel = input.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]).unwrap_or([0u8; 4]);
 
@@ -517,7 +517,7 @@ impl PredeployHandler for ArbAddressTable {
         self.addr
     }
 
-    fn call(&self, _ctx: &PredeployCallContext, input: &Bytes, gas_limit: u64, _value: U256, _retryables: &mut dyn Retryables) -> (Bytes, u64, bool) {
+    fn call(&self, _ctx: &PredeployCallContext, input: &Bytes, gas_limit: u64, _value: U256, retryables: &mut dyn Retryables) -> (Bytes, u64, bool) {
         use arb_alloy_predeploys as pre;
         let sel = input.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]).unwrap_or([0u8; 4]);
         let at_exists = pre::selector(pre::SIG_AT_ADDRESS_EXISTS);

--- a/crates/arbitrum/evm/src/retryables.rs
+++ b/crates/arbitrum/evm/src/retryables.rs
@@ -47,18 +47,15 @@ impl Retryables for DefaultRetryables {
     }
 
     fn redeem_retryable(&mut self, ticket_id: &RetryableTicketId) -> RetryableAction {
-        let _ = ticket_id;
-        RetryableAction::Redeemed { ticket_id: RetryableTicketId([0u8; 32]), success: false }
+        RetryableAction::Redeemed { ticket_id: RetryableTicketId(ticket_id.0), success: false }
     }
 
     fn cancel_retryable(&mut self, ticket_id: &RetryableTicketId) -> RetryableAction {
-        let _ = ticket_id;
-        RetryableAction::Canceled { ticket_id: RetryableTicketId([0u8; 32]) }
+        RetryableAction::Canceled { ticket_id: RetryableTicketId(ticket_id.0) }
     }
 
     fn keepalive_retryable(&mut self, ticket_id: &RetryableTicketId) -> RetryableAction {
-        let _ = ticket_id;
-        RetryableAction::KeptAlive { ticket_id: RetryableTicketId([0u8; 32]) }
+        RetryableAction::KeptAlive { ticket_id: RetryableTicketId(ticket_id.0) }
     }
 }
 

--- a/crates/arbitrum/primitives/Cargo.toml
+++ b/crates/arbitrum/primitives/Cargo.toml
@@ -12,4 +12,14 @@ std = [
 ]
 
 [dependencies]
+# alloy core crates used in primitives
 alloy-consensus = { version = "1", default-features = false, features = ["std"] }
+alloy-eips = { version = "1", default-features = false }
+alloy-rlp = { version = "0.3", default-features = false, features = ["derive"] }
+alloy-primitives = { version = "1.3", default-features = false, features = ["rlp"] }
+
+# arb-alloy consensus types
+arb-alloy-consensus = { path = "../../../../arb-alloy/crates/consensus", default-features = false }
+
+# reth primitives traits from workspace
+reth-primitives-traits = { path = "../../primitives-traits", default-features = false, package = "reth-primitives-traits" }

--- a/crates/arbitrum/stf-wasm/src/lib.rs
+++ b/crates/arbitrum/stf-wasm/src/lib.rs
@@ -35,4 +35,44 @@ mod tests {
 
         assert_eq!(&out[..out_len], &out2[..out_len2]);
     }
+    #[test]
+    fn record_block_inputs_hash_is_deterministic_for_same_inputs() {
+        use alloy_primitives::keccak256;
+        let input = b"arb-stf-inputs-1234567890";
+        let mut out1 = vec![0u8; input.len()];
+        let mut out_len1: usize = 0;
+        let rc1 = unsafe { record_block_inputs(input.as_ptr(), input.len(), out1.as_mut_ptr(), &mut out_len1 as *mut usize) };
+        assert_eq!(rc1, 0);
+
+        let mut out2 = vec![0u8; input.len()];
+        let mut out_len2: usize = 0;
+        let rc2 = unsafe { record_block_inputs(input.as_ptr(), input.len(), out2.as_mut_ptr(), &mut out_len2 as *mut usize) };
+        assert_eq!(rc2, 0);
+
+        assert_eq!(&out1[..out_len1], &out2[..out_len2]);
+        let h1 = keccak256(&out1[..out_len1]);
+        let h2 = keccak256(&out2[..out_len2]);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn record_block_inputs_hash_differs_for_different_inputs() {
+        use alloy_primitives::keccak256;
+        let a = b"aaaa";
+        let b = b"bbbb";
+        let mut out_a = vec![0u8; a.len()];
+        let mut out_b = vec![0u8; b.len()];
+        let mut len_a: usize = 0;
+        let mut len_b: usize = 0;
+
+        unsafe {
+            record_block_inputs(a.as_ptr(), a.len(), out_a.as_mut_ptr(), &mut len_a as *mut usize);
+            record_block_inputs(b.as_ptr(), b.len(), out_b.as_mut_ptr(), &mut len_b as *mut usize);
+        }
+
+        let ha = keccak256(&out_a[..len_a]);
+        let hb = keccak256(&out_b[..len_b]);
+        assert_ne!(ha, hb);
+    }
+
 }

--- a/crates/arbitrum/stf-wasm/src/lib.rs
+++ b/crates/arbitrum/stf-wasm/src/lib.rs
@@ -12,3 +12,27 @@ pub extern "C" fn record_block_inputs(ptr: *const u8, len: usize, out_ptr: *mut 
     }
     0
 }
+#[cfg(test)]
+mod tests {
+    use super::record_block_inputs;
+
+    #[test]
+    fn record_block_inputs_is_deterministic_and_roundtrips() {
+        let input = b"arb-stf-inputs-v0:canonical-order-check";
+        let mut out = vec![0u8; input.len()];
+        let mut out_len: usize = 0;
+        let rc1 = unsafe { record_block_inputs(input.as_ptr(), input.len(), out.as_mut_ptr(), &mut out_len as *mut usize) };
+        assert_eq!(rc1, 0);
+        assert_eq!(out_len, input.len());
+        assert_eq!(&out[..out_len], input);
+
+        let mut out2 = vec![0u8; input.len()];
+        let mut out_len2: usize = 0;
+        let rc2 = unsafe { record_block_inputs(input.as_ptr(), input.len(), out2.as_mut_ptr(), &mut out_len2 as *mut usize) };
+        assert_eq!(rc2, 0);
+        assert_eq!(out_len2, input.len());
+        assert_eq!(&out2[..out_len2], input);
+
+        assert_eq!(&out[..out_len], &out2[..out_len2]);
+    }
+}


### PR DESCRIPTION
# arb-reth: Arbitrum integration scaffolding (Nitro parity) — hooks, predeploys, primitives, Docker, tests

## Summary

This PR implements the foundational scaffolding for reth as an alternative execution client to nitro-geth for Arbitrum networks. The implementation focuses on maintaining exact consensus parity with Nitro while extending reth through dedicated crates rather than forking the base implementation.

**Key Components Added:**
- **Arbitrum transaction primitives** with 2718 envelope support and signer recovery
- **ArbOS execution hooks** for fee flow (Start/GasCharging/End) with L1 pricing integration  
- **Predeploy handlers** for ArbSys, ArbRetryableTx, ArbOwner, NodeInterface, ArbGasInfo, ArbAddressTable
- **Receipt mapping parity** ensuring consensus receipts exclude L1 fee fields
- **Retryables lifecycle** management with escrow accounting
- **STF WASM determinism** for proving compatibility
- **Docker build infrastructure** with proper toolchain and dependency management

The implementation leverages arb-alloy primitives extensively rather than duplicating code, ensuring consistency with upstream Arbitrum type definitions.

## Review & Testing Checklist for Human

- [ ] **Verify transaction type mappings work correctly** - Test that all ArbTxEnvelope variants (Deposit, Unsigned, Contract, Retry, SubmitRetryable, Internal, Legacy) decode properly and recover expected signers
- [ ] **Test Docker image builds successfully** - Run `docker build -t arb-reth:local -f crates/arbitrum/bin/Dockerfile .` from reth root to ensure all toolchain changes work  
- [ ] **Validate predeploy ABI encodings match Nitro exactly** - Cross-check selector constants and return value encodings against Nitro's solgen output
- [ ] **Verify deterministic execution and receipt parity** - Ensure consensus receipts exclude L1 fees and STF produces identical hashes for identical inputs
- [ ] **Integration test with Arbitrum stack** - Build arb-reth image and test with Kurtosis package to verify L2 block production works

**Recommended Test Plan:**
1. Run unit tests: `cargo test -p reth-arbitrum-evm -p reth-arbitrum-primitives`  
2. Build Docker image locally and verify it starts without errors
3. Deploy minimal Arbitrum network using Kurtosis package and verify L2 blocks are produced
4. Test predeploy method calls via RPC to validate ABI compliance

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    subgraph "reth/crates/arbitrum/"
        primitives["primitives/src/lib.rs<br/>ArbTransactionSigned<br/>Typed2718 impl"]:::major-edit
        evm_lib["evm/src/lib.rs<br/>Transaction Iterator<br/>Envelope Decoding"]:::major-edit
        execute["evm/src/execute.rs<br/>ArbOS Hooks<br/>Fee Flow"]:::major-edit
        predeploys["evm/src/predeploys.rs<br/>ArbOwner Handler<br/>State Management"]:::major-edit
        retryables["evm/src/retryables.rs<br/>Lifecycle Management"]:::context
        receipts["evm/src/receipts.rs<br/>Receipt Mapping"]:::context
        stf_wasm["stf-wasm/src/lib.rs<br/>Determinism Tests"]:::context
        dockerfile["bin/Dockerfile<br/>Build Infrastructure"]:::major-edit
    end
    
    subgraph "Workspace"
        cargo_toml["Cargo.toml<br/>revm-precompile pin"]:::minor-edit
        primitives_cargo["primitives/Cargo.toml<br/>arb-alloy deps"]:::minor-edit
    end
    
    subgraph "arb-alloy (external)"
        arb_consensus["arb-alloy-consensus<br/>ArbTxEnvelope types"]:::context
        arb_predeploys["arb-alloy-predeploys<br/>Selector constants"]:::context
    end

    primitives --> arb_consensus
    predeploys --> arb_predeploys
    evm_lib --> primitives
    execute --> primitives
    predeploys --> retryables
    dockerfile --> cargo_toml
    primitives_cargo --> arb_consensus

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Consensus Critical**: All transaction encodings, receipt formats, and predeploy behaviors must match Nitro exactly to maintain network consensus
- **Incomplete Implementation**: Several predeploy handlers (ArbSys sendTxToL1/withdraw, NodeInterface components) contain placeholder logic that needs completion
- **Build Dependencies**: Docker image requires Rust 1.81+ with nightly toolchain and additional system packages (clang, libclang-dev, etc.)
- **Testing Gaps**: Full integration testing requires running complete Arbitrum stack with L1/L2 coordination

**Session Info:**
- Link to Devin run: https://app.devin.ai/sessions/3a1f6008621d48a4bd1f50124eac20db
- Requested by: Til Jordan (@tiljrd)