### PR TITLE
fix(arbitrum/chainspec): derive hardforks via ChainSpec::from_genesis for baked genesis

### DIFF
--- a/crates/arbitrum/chainspec/src/lib.rs
+++ b/crates/arbitrum/chainspec/src/lib.rs
@@ -594,10 +594,7 @@ pub fn sepolia_baked_genesis_from_header(
 
     genesis.alloc = alloc;
 
-    let spec = reth_chainspec::ChainSpec::builder()
-        .chain(Chain::from(chain_id))
-        .genesis(genesis)
-        .build();
+    let spec = reth_chainspec::ChainSpec::from_genesis(genesis);
     Ok(spec)
 }
 


### PR DESCRIPTION
# Implement CLI and Genesis Parity with Nitro for Sepolia

## Summary

This PR implements CLI and genesis parity between the Rust Arbitrum node (nitro-rs + reth) and the official Go Nitro node on Sepolia. The key changes include:

- **CLI compatibility**: Enhanced CLI flag mapping to accept Nitro flags (`--chain.name`, `--parent-chain.connection.url`, etc.) with proper warnings for ignored flags
- **Baked genesis implementation**: Added support for building Sepolia chainspec from L2 block 0 header data, matching Nitro's approach
- **Genesis validation**: Runtime validation that compares our generated genesis hash against live L2 block 0 hash
- **Critical reth fix**: Fixed chainspec hardfork derivation in `sepolia_baked_genesis_from_header` to ensure base fees are calculated correctly
- **Test infrastructure**: Added unit tests for CLI parsing, chaininfo selection, and genesis header parity

**Cross-repository changes**: This PR coordinates with a companion PR in `tiljrd/reth` that fixes chainspec hardfork derivation.

## Review & Testing Checklist for Human

- [ ] **Verify genesis header parity**: Check that the baked genesis test `baked_genesis_header_fields_match_inputs` produces the correct `baseFeePerGas` (0x3b9aca00) and other header fields match Nitro exactly
- [ ] **Review reth chainspec fix**: Confirm that switching from `ChainSpec::builder().build()` to `ChainSpec::from_genesis()` correctly derives hardforks from genesis config (this was the root cause of the baseFee bug)
- [ ] **Test CLI flag compatibility**: Verify that common Nitro command lines work with appropriate warnings for ignored flags, and that help/version passthrough still functions
- [ ] **Validate chaininfo address sourcing**: Ensure rollup contract addresses are properly sourced from `arbitrum_chain_info.json` for Sepolia
- [ ] **End-to-end testing plan**: Once confident in the changes, test the actual Rust node startup against Sepolia (without syncing) to verify genesis validation passes and no runtime errors occur

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
flowchart TD
    CLI["bin/arb-nitro-rs/src/main.rs<br/>CLI Entry Point"]:::major-edit
    Config["crates/node/src/config.rs<br/>NodeArgs + Default"]:::major-edit
    Service["crates/node/src/service.rs<br/>Node Startup + Genesis Validation"]:::major-edit
    Genesis["crates/node/src/genesis.rs<br/>Baked Genesis Builder"]:::major-edit
    ChainInfo["crates/node/src/chaininfo.rs<br/>Chain Config Selection"]:::minor-edit
    RethChainspec["reth/crates/arbitrum/chainspec/src/lib.rs<br/>ChainSpec Builder"]:::major-edit
    Test["crates/node/tests/feed_server.rs<br/>Updated Test"]:::minor-edit
    
    CLI --> Config
    CLI --> Service
    Service --> Genesis
    Service --> ChainInfo
    Genesis --> RethChainspec
    Config --> Test
    
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Critical bug fix**: The reth chainspec change fixes a subtle but critical issue where hardforks weren't being derived from genesis config, causing `baseFeePerGas` to be 0 instead of the expected 1 gwei
- **No node execution yet**: Following the approved plan, we've implemented and tested the changes without actually running the Rust node - this should be done in a follow-up once the human reviewer is confident in the implementation
- **Companion PR**: This coordinates with reth PR that must be merged first or simultaneously

**Session**: https://app.devin.ai/sessions/2a79cc19305a4d86a6d28c3553bb103a  
**Requested by**: Til Jordan (@tiljrd)