### PR TITLE
feat(arbitrum/evm): add read_l2_base_fee helper and wire follower

### DIFF
--- a/crates/arbitrum/evm/src/header.rs
+++ b/crates/arbitrum/evm/src/header.rs
@@ -1,5 +1,5 @@
 use alloy_consensus::Header;
-use alloy_primitives::{keccak256, Address, B256, Bytes, U256};
+use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 pub fn extract_send_root_from_header_extra(extra: &[u8]) -> B256 {
     if extra.len() >= 32 {
         B256::from_slice(&extra[..32])
@@ -125,9 +125,7 @@ fn merkle_root_from_partials(
     hash_so_far
 }
 
-pub fn derive_arb_header_info_from_state<
-    F: for<'a> alloy_evm::block::BlockExecutorFactory,
->(
+pub fn derive_arb_header_info_from_state<F: for<'a> alloy_evm::block::BlockExecutorFactory>(
     input: &reth_evm::execute::BlockAssemblerInput<'_, '_, F, Header>,
 ) -> Option<ArbHeaderInfo> {
     let provider = input.state_provider;
@@ -163,4 +161,11 @@ pub fn read_l2_per_block_gas_limit(provider: &dyn StateProvider) -> Option<u64> 
     let l2_pricing_subspace = subspace(&root_storage_key, &[1u8]);
     let per_block_gas_limit_slot = storage_key_map(&l2_pricing_subspace, uint_to_hash_u64_be(1));
     read_storage_u64_be(provider, addr, per_block_gas_limit_slot)
+}
+pub fn read_l2_base_fee(provider: &dyn StateProvider) -> Option<u64> {
+    let addr = arbos_state_address();
+    let root_storage_key: [u8; 32] = [0u8; 32];
+    let l2_pricing_subspace = subspace(&root_storage_key, &[1u8]);
+    let price_per_unit_slot = storage_key_map(&l2_pricing_subspace, uint_to_hash_u64_be(2));
+    read_storage_u64_be(provider, addr, price_per_unit_slot)
 }


### PR DESCRIPTION
# feat(arbitrum/evm): add read_l2_base_fee helper and wire follower

## Summary

Adds the missing `read_l2_base_fee` function to `reth_arbitrum_evm::header` module to fix build errors in the Rust Arbitrum node implementation. This function reads the L2 base fee (price per unit) from ArbOS state storage and is used by the follower execution logic to set appropriate gas fees.

**Key Changes:**
- Added `read_l2_base_fee()` function that reads from ArbOS l2pricing subspace, slot 2 (pricePerUnit)
- Function mirrors the existing `read_l2_per_block_gas_limit()` pattern
- Enables the follower code in `node.rs` to compile and access L2 pricing data from ArbOS state

## Review & Testing Checklist for Human

- [ ] **Verify ArbOS storage mapping**: Confirm that l2pricing subspace slot 2 corresponds to `pricePerUnit` in the reference Nitro implementation
- [ ] **Test against live Arbitrum state**: Call this function against real Sepolia ArbOS state and verify it returns sensible L2 base fee values (not zero/garbage)
- [ ] **End-to-end build verification**: Confirm both `arb-reth` and `arb-nitro-rs` build successfully with this change and path-based dependencies

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    node_rs["crates/arbitrum/node/src/node.rs<br/>[Follower execution logic]"]:::context
    header_rs["crates/arbitrum/evm/src/header.rs<br/>[ArbOS state readers]"]:::major-edit
    chainspec_toml["crates/arbitrum/chainspec/Cargo.toml<br/>[Fixed duplicate deps]"]:::minor-edit
    
    node_rs -->|"calls read_l2_base_fee()"| header_rs
    header_rs -->|"reads from ArbOS<br/>l2pricing.pricePerUnit"| arbos_state[("ArbOS State Storage<br/>(subspace [1], slot 2)")]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This resolves the "cannot find function `read_l2_base_fee`" build error reported by the user
- The storage slot mapping (l2pricing subspace, slot 2) follows the same pattern as the existing `read_l2_per_block_gas_limit` function
- Follower code uses this for `max_fee_per_gas` calculation with L1 base fee fallback
- Part of broader effort to ensure Rust Arbitrum node has exact parity with Nitro's genesis and execution logic


**Session**: https://app.devin.ai/sessions/2a79cc19305a4d86a6d28c3553bb103a  
**Requested by**: Til Jordan (@tiljrd)