### PR TITLE
Arbitrum parity: early-block mixHash source and Sepolia gasLimit fallback

### DIFF
--- a/crates/arbitrum/evm/src/header.rs
+++ b/crates/arbitrum/evm/src/header.rs
@@ -1,5 +1,14 @@
 use alloy_consensus::Header;
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+
+pub fn compute_nitro_mixhash(send_count: u64, l1_block_number: u64, arbos_version: u64) -> B256 {
+    let mut mix = [0u8; 32];
+    mix[0..8].copy_from_slice(&send_count.to_be_bytes());
+    mix[8..16].copy_from_slice(&l1_block_number.to_be_bytes());
+    mix[16..24].copy_from_slice(&arbos_version.to_be_bytes());
+    B256::from(mix)
+}
+
 pub fn extract_send_root_from_header_extra(extra: &[u8]) -> B256 {
     if extra.len() >= 32 {
         B256::from_slice(&extra[..32])
@@ -7,7 +16,7 @@ pub fn extract_send_root_from_header_extra(extra: &[u8]) -> B256 {
         B256::ZERO
     }
 }
-
+ 
 use reth_storage_api::StateProvider;
 
 #[derive(Clone, Debug, Default)]

--- a/crates/arbitrum/evm/src/header.rs
+++ b/crates/arbitrum/evm/src/header.rs
@@ -148,6 +148,10 @@ pub fn derive_arb_header_info_from_state<F: for<'a> alloy_evm::block::BlockExecu
     let l1_block_num_slot = storage_key_map(&blockhashes_sub, uint_to_hash_u64_be(0));
     let l1_block_number = read_storage_u64_be(provider, addr, l1_block_num_slot).unwrap_or(0);
 
+    if l1_block_number == 0 {
+        return None;
+    }
+
     Some(ArbHeaderInfo {
         send_root,
         send_count,

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -318,7 +318,7 @@ where
             reth_tracing::tracing::info!(target: "arb-reth::follower", derived_gas_limit = gl, "using ArbOS per-block gas limit for next block");
             next_env.gas_limit = gl;
         } else {
-            const INITIAL_PER_BLOCK_GAS_LIMIT_NITRO: u64 = 0x10000000000000;
+            const INITIAL_PER_BLOCK_GAS_LIMIT_NITRO: u64 = 0x4000000000000;
             reth_tracing::tracing::warn!(target: "arb-reth::follower", "failed to read L2_PER_BLOCK_GAS_LIMIT; using Nitro default {}", INITIAL_PER_BLOCK_GAS_LIMIT_NITRO);
             next_env.gas_limit = INITIAL_PER_BLOCK_GAS_LIMIT_NITRO;
         }

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -318,9 +318,9 @@ where
             reth_tracing::tracing::info!(target: "arb-reth::follower", derived_gas_limit = gl, "using ArbOS per-block gas limit for next block");
             next_env.gas_limit = gl;
         } else if next_env.gas_limit == 0 {
-            const INITIAL_PER_BLOCK_GAS_LIMIT_V0: u64 = 20_000_000;
-            reth_tracing::tracing::warn!(target: "arb-reth::follower", "failed to read L2_PER_BLOCK_GAS_LIMIT; using default {}", INITIAL_PER_BLOCK_GAS_LIMIT_V0);
-            next_env.gas_limit = INITIAL_PER_BLOCK_GAS_LIMIT_V0;
+            const INITIAL_PER_BLOCK_GAS_LIMIT_NITRO: u64 = 0x10000000000000;
+            reth_tracing::tracing::warn!(target: "arb-reth::follower", "failed to read L2_PER_BLOCK_GAS_LIMIT; using Nitro default {}", INITIAL_PER_BLOCK_GAS_LIMIT_NITRO);
+            next_env.gas_limit = INITIAL_PER_BLOCK_GAS_LIMIT_NITRO;
         }
 
         let mut builder = evm_config

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -323,6 +323,18 @@ where
             next_env.gas_limit = INITIAL_PER_BLOCK_GAS_LIMIT_NITRO;
         }
 
+        if kind == 13 {
+            let mut cur = &l2_owned[..];
+            if cur.len() >= 32 + 20 {
+                cur = &cur[32..];
+                let mut poster_bytes = [0u8; 20];
+                poster_bytes.copy_from_slice(&cur[..20]);
+                let batch_poster_addr = alloy_primitives::Address::from(poster_bytes);
+                reth_tracing::tracing::info!(target: "arb-reth::follower", beneficiary = %batch_poster_addr, "setting beneficiary from BatchPostingReport");
+                next_env.suggested_fee_recipient = batch_poster_addr;
+            }
+        }
+
         let mut builder = evm_config
             .builder_for_next_block(&mut db, &sealed_parent, next_env)
             .map_err(|e| eyre::eyre!("builder_for_next_block error: {e}"))?;

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -317,7 +317,7 @@ where
         {
             reth_tracing::tracing::info!(target: "arb-reth::follower", derived_gas_limit = gl, "using ArbOS per-block gas limit for next block");
             next_env.gas_limit = gl;
-        } else if next_env.gas_limit == 0 {
+        } else {
             const INITIAL_PER_BLOCK_GAS_LIMIT_NITRO: u64 = 0x10000000000000;
             reth_tracing::tracing::warn!(target: "arb-reth::follower", "failed to read L2_PER_BLOCK_GAS_LIMIT; using Nitro default {}", INITIAL_PER_BLOCK_GAS_LIMIT_NITRO);
             next_env.gas_limit = INITIAL_PER_BLOCK_GAS_LIMIT_NITRO;

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -334,6 +334,14 @@ where
                 next_env.suggested_fee_recipient = batch_poster_addr;
             }
         }
+        if next_env.suggested_fee_recipient == alloy_primitives::Address::ZERO {
+            let sugg = attrs.suggested_fee_recipient;
+            if sugg != alloy_primitives::Address::ZERO {
+                next_env.suggested_fee_recipient = sugg;
+            } else {
+                next_env.suggested_fee_recipient = poster;
+            }
+        }
 
         let mut builder = evm_config
             .builder_for_next_block(&mut db, &sealed_parent, next_env)

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -327,7 +327,11 @@ where
             next_env.gas_limit = INITIAL_PER_BLOCK_GAS_LIMIT_NITRO;
         }
 
-        if kind == 13 {
+        let sugg = attrs.suggested_fee_recipient;
+        if sugg != alloy_primitives::Address::ZERO {
+            next_env.suggested_fee_recipient = sugg;
+        }
+        if next_env.suggested_fee_recipient == alloy_primitives::Address::ZERO && kind == 13 {
             let mut cur = &l2_owned[..];
             if cur.len() >= 32 + 20 {
                 cur = &cur[32..];
@@ -339,12 +343,7 @@ where
             }
         }
         if next_env.suggested_fee_recipient == alloy_primitives::Address::ZERO {
-            let sugg = attrs.suggested_fee_recipient;
-            if sugg != alloy_primitives::Address::ZERO {
-                next_env.suggested_fee_recipient = sugg;
-            } else {
-                next_env.suggested_fee_recipient = poster;
-            }
+            next_env.suggested_fee_recipient = poster;
         }
 
         let mut builder = evm_config

--- a/crates/arbitrum/node/src/rpc.rs
+++ b/crates/arbitrum/node/src/rpc.rs
@@ -65,6 +65,14 @@ where
             ctx.config.engine.accept_execution_requests_hash,
         );
 
+        {
+            let provider = ctx.node.provider();
+            if let Ok(best) = provider.best_block_number() {
+                if let Ok(h) = provider.header_by_number(best) {
+                    reth_tracing::tracing::info!(target: "arb-reth::rpc", best_number = best, best_hash = ?h.map(|hdr| hdr.hash()), "rpc: initial provider head");
+                }
+            }
+        }
 
         Ok(reth_arbitrum_rpc::engine::ArbEngineApi::new(inner))
     }

--- a/crates/arbitrum/node/src/rpc.rs
+++ b/crates/arbitrum/node/src/rpc.rs
@@ -12,6 +12,9 @@ use crate::ARB_NAME_CLIENT;
 use reth_arbitrum_rpc::engine::ARB_ENGINE_CAPABILITIES;
 use reth_arbitrum_payload::ArbExecutionData;
 
+use reth_storage_api::BlockNumReader;
+use reth_provider::HeaderProvider;
+
 #[derive(Debug, Default, Clone)]
 pub struct ArbEngineApiBuilder<EV> {
     engine_validator_builder: EV,
@@ -68,9 +71,7 @@ where
         {
             let provider = ctx.node.provider();
             if let Ok(best) = provider.best_block_number() {
-                if let Ok(h) = provider.header_by_number(best) {
-                    reth_tracing::tracing::info!(target: "arb-reth::rpc", best_number = best, best_hash = ?h.map(|hdr| hdr.hash()), "rpc: initial provider head");
-                }
+                reth_tracing::tracing::info!(target: "arb-reth::rpc", best_number = best, "rpc: initial provider head");
             }
         }
 


### PR DESCRIPTION
# Arbitrum parity: early-block mixHash source and Sepolia gasLimit fallback

## Summary
Fixes block derivation parity issues with official Arbitrum Sepolia by addressing three key areas:
1. **Early block mixHash**: Skip deriving `ArbHeaderInfo` from state when L1 block number is 0, allowing early blocks to use `prev_randao` as mixHash source instead
2. **Gas limit fallback**: Update fallback per-block gas limit from 20M to `0x4000000000000` to match Nitro's actual default for Sepolia
3. **Beneficiary/coinbase**: Extract batch poster address from `BatchPostingReport` messages (kind 13) and set as `suggested_fee_recipient`

These changes aim to ensure block hashes and transaction ordering match the official Arbitrum Sepolia RPC.

## Review & Testing Checklist for Human
- [ ] **Verify gas limit constant**: Confirm `0x4000000000000` matches Nitro's exact fallback for Sepolia (high impact if wrong)
- [ ] **Test BatchPostingReport parsing**: Validate the buffer parsing logic (skip 32 bytes, read 20 bytes for address) against actual message format
- [ ] **Compare early block headers**: Test blocks 1, 2, 10, 100 against official RPC - verify `gasLimit`, `miner`, `mixHash` now match
- [ ] **Regression test**: Ensure later blocks (after ArbOS state populated) still derive correctly and don't break
- [ ] **End-to-end sync**: Run full sync and verify block hashes match official chain throughout

### Notes
- The header derivation change specifically targets early blocks where ArbOS state may not have L1 block info yet
- Manual byte parsing in BatchPostingReport extraction is consensus-critical - any offset errors would cause beneficiary mismatches
- Gas limit change is substantial (20M → ~1.1T) but matches what official Sepolia uses

Link to Devin run: https://app.devin.ai/sessions/84d0c29ea53b48448e5d944face31bc8  
Requested by: Til Jordan (@tiljrd)