### PR TITLE
arbitrum/node: add delayed_messages_read to FollowerExecutor trait and handle

### DIFF
--- a/crates/arbitrum/node/src/follower.rs
+++ b/crates/arbitrum/node/src/follower.rs
@@ -18,6 +18,7 @@ pub trait FollowerExecutor: Send + Sync {
         request_id: Option<B256>,
         kind: u8,
         l1_block_number: u64,
+        delayed_messages_read: u64,
         l1_base_fee: U256,
         batch_gas_cost: Option<u64>,
     ) -> Pin<Box<dyn Future<Output = Result<(B256, B256)>> + Send + '_>>;
@@ -51,6 +52,7 @@ impl FollowerExecutor for FollowerExecutorHandle {
         request_id: Option<B256>,
         kind: u8,
         l1_block_number: u64,
+        delayed_messages_read: u64,
         l1_base_fee: U256,
         batch_gas_cost: Option<u64>,
     ) -> Pin<Box<dyn Future<Output = Result<(B256, B256)>> + Send>> {
@@ -79,6 +81,7 @@ impl FollowerExecutor for FollowerExecutorHandle {
                         request_id,
                         kind,
                         l1_block_number,
+                        delayed_messages_read,
                         l1_base_fee,
                         batch_gas_cost,
                     )


### PR DESCRIPTION
# arbitrum/node: add delayed_messages_read to FollowerExecutor trait and handle

## Summary
Fixes compilation error: `method 'execute_message_to_block' has 11 parameters but the declaration in trait 'FollowerExecutor::execute_message_to_block' has 10`.

The trait signature was missing the `delayed_messages_read: u64` parameter that was already present in the implementation (`ArbFollowerExec` in `node.rs`) and expected by call sites in `nitro-rs`. This change adds the missing parameter to:
- `FollowerExecutor` trait definition  
- `FollowerExecutorHandle` implementation signature
- Parameter forwarding in the handle's async execution

The parameter is inserted after `l1_block_number` to match the existing implementation and call site order.

## Review & Testing Checklist for Human
- [ ] Verify `cargo build --release` succeeds in both `nitro-rs` and `reth` repositories
- [ ] Confirm parameter order matches exactly between trait, handle, implementation in `node.rs`, and nitro-rs call sites  
- [ ] Check for any other implementations of `FollowerExecutor` trait that might need updating

### Notes
This is a mechanical fix to align signatures across the codebase. The `delayed_messages_read` parameter was already being used correctly in the implementation and passed by callers - only the trait definition was missing it.

**Link to Devin run:** https://app.devin.ai/sessions/3abadde4675d4267bbe82d09aba96a22  
**Requested by:** Til Jordan (@tiljrd)