### PR TITLE
arbitrum: accept non-zero header.nonce post-merge to match Nitro (remove zero-nonce check)

### DIFF
--- a/crates/arbitrum/node/src/consensus.rs
+++ b/crates/arbitrum/node/src/consensus.rs
@@ -92,9 +92,6 @@ where
 {
     fn validate_header(&self, header: &SealedHeader<H>) -> Result<(), ConsensusError> {
         let h = header.header();
-        if h.nonce() != Some(B64::ZERO) {
-            return Err(ConsensusError::TheMergeNonceIsNotZero);
-        }
         if h.ommers_hash() != EMPTY_OMMER_ROOT_HASH {
             return Err(ConsensusError::TheMergeOmmerRootIsNotEmpty);
         }


### PR DESCRIPTION
# arbitrum: accept non-zero header.nonce post-merge to match Nitro (remove zero-nonce check)

## Summary

Removes the Ethereum post-merge consensus rule that requires `header.nonce` to be zero for Arbitrum headers. This fixes "nonce after merge is not zero" validation errors in the Arbitrum engine.

**Root cause**: Ethereum post-merge requires zero nonce, but Arbitrum uses `header.nonce` to encode `delayedMessagesRead` count, making the zero-nonce check incompatible with Arbitrum's consensus model.

**Change**: Removed the `TheMergeNonceIsNotZero` validation check from `ArbBeaconConsensus::validate_header()` while preserving other post-merge validations (ommers hash check).

## Review & Testing Checklist for Human

- [ ] **Verify Nitro reference**: Check `tiljrd/nitro` go-ethereum code to confirm `header.Nonce` actually stores `delayedMessagesRead`
- [ ] **Test original error fix**: Run nitro-rs follower to confirm `newPayload` no longer returns "nonce after merge is not zero" 
- [ ] **Consensus isolation**: Verify this change only affects Arbitrum consensus and doesn't impact Ethereum/Optimism validation rules
- [ ] **Integration testing**: Test with actual Arbitrum block data to ensure no consensus regressions

### Notes

This change addresses a critical bug preventing Arbitrum nitro-rs from processing blocks. The validation rule was inherited from Ethereum but conflicts with Arbitrum's use of the nonce field for protocol-specific data.

**Session**: https://app.devin.ai/sessions/c1615ec2bfff4fb7826e9917c35723b0  
**Requested by**: @tiljrd