### PR TITLE
Arbitrum RPC: add Nitro fields for 0x69/0x68 and emit Retry after SubmitRetryable (block 0x1 parity)

### DIFF
--- a/crates/arbitrum/rpc/src/eth/mod.rs
+++ b/crates/arbitrum/rpc/src/eth/mod.rs
@@ -26,6 +26,7 @@ pub mod txinfo;
 use reth_tasks::pool::{BlockingTaskGuard, BlockingTaskPool};
 use reth_tasks::TaskSpawner;
 use reth_arbitrum_primitives::ArbTransactionSigned;
+pub mod response;
 
 #[derive(Clone, Debug)]
 pub struct ArbRpcTypes;
@@ -33,7 +34,7 @@ pub struct ArbRpcTypes;
 impl reth_rpc_eth_api::RpcTypes for ArbRpcTypes {
     type Header = alloy_rpc_types_eth::Header<alloy_consensus::Header>;
     type Receipt = alloy_rpc_types_eth::TransactionReceipt;
-    type TransactionResponse = alloy_rpc_types_eth::Transaction<ArbTransactionSigned>;
+    type TransactionResponse = crate::eth::response::ArbTransactionResponse;
     type TransactionRequest = crate::eth::transaction::ArbTransactionRequest;
 }
 

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -1,0 +1,100 @@
+use serde::{Deserialize, Serialize};
+
+use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_rpc_types_eth::{Transaction as EthTransaction, TransactionInfo};
+use reth_rpc_convert::transaction::FromConsensusTx;
+
+use reth_arbitrum_primitives::{ArbTransactionSigned, ArbTypedTransaction};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ArbTransactionResponse {
+    #[serde(flatten)]
+    pub inner: EthTransaction<ArbTransactionSigned>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requestId: Option<B256>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refundTo: Option<Address>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub l1BaseFee: Option<U256>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub depositValue: Option<U256>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryTo: Option<Address>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryValue: Option<U256>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryData: Option<Bytes>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beneficiary: Option<Address>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maxSubmissionFee: Option<U256>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ticketId: Option<B256>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maxRefund: Option<U256>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub submissionFeeRefund: Option<U256>,
+}
+
+impl FromConsensusTx<ArbTransactionSigned> for ArbTransactionResponse {
+    type TxInfo = TransactionInfo;
+
+    fn from_consensus_tx(
+        tx: ArbTransactionSigned,
+        signer: Address,
+        tx_info: Self::TxInfo,
+    ) -> Self {
+        let inner = EthTransaction::from_transaction(reth_rpc_convert::transaction::Recovered::new_unchecked(tx.clone(), signer), tx_info);
+
+        let mut out = ArbTransactionResponse {
+            inner,
+            requestId: None,
+            refundTo: None,
+            l1BaseFee: None,
+            depositValue: None,
+            retryTo: None,
+            retryValue: None,
+            retryData: None,
+            beneficiary: None,
+            maxSubmissionFee: None,
+            ticketId: None,
+            maxRefund: None,
+            submissionFeeRefund: None,
+        };
+
+        match &*tx {
+            ArbTypedTransaction::SubmitRetryable(s) => {
+                out.requestId = Some(s.request_id);
+                out.refundTo = Some(s.fee_refund_addr);
+                out.l1BaseFee = Some(s.l1_base_fee);
+                out.depositValue = Some(s.deposit_value);
+                out.retryTo = s.retry_to;
+                out.retryValue = Some(s.retry_value);
+                out.retryData = Some(s.retry_data.clone());
+                out.beneficiary = Some(s.beneficiary);
+                out.maxSubmissionFee = Some(s.max_submission_fee);
+            }
+            ArbTypedTransaction::Retry(r) => {
+                out.ticketId = Some(r.ticket_id);
+                out.maxRefund = Some(r.max_refund);
+                out.submissionFeeRefund = Some(r.submission_fee_refund);
+                out.refundTo = Some(r.refund_to);
+            }
+            _ => {}
+        }
+
+        out
+    }
+}


### PR DESCRIPTION
# Arbitrum RPC: add Nitro fields for 0x69/0x68 and emit Retry after SubmitRetryable (block 0x1 parity)

## Summary

This PR fixes the mismatch between the Rust Arbitrum node and official Arbitrum Sepolia for block 0x1 transaction contents. Previously, the Rust node only showed 1 transaction while the official node shows 3 transactions (types 0x6a, 0x69, 0x68).

**Changes:**
1. **Transaction processing**: Modified L2 message handling (kind=9) to emit both SubmitRetryable (0x69) AND Retry (0x68) transactions instead of just SubmitRetryable
2. **RPC response**: Created `ArbTransactionResponse` that includes Nitro-specific fields (`requestId`, `ticketId`, `refundTo`, `l1BaseFee`, `depositValue`, etc.) for proper 0x69/0x68 serialization
3. **Integration**: Wired the custom response type into `ArbRpcTypes::TransactionResponse` following the Optimism pattern

## Review & Testing Checklist for Human

- [ ] **End-to-end test**: Run the node and verify block 0x1 now returns exactly 3 transactions with hashes matching official Arbitrum Sepolia (`0x1ac8d6...`, `0x13cb79...`, `0x873c5e...`)
- [ ] **RPC field verification**: Compare RPC output fields for 0x69/0x68 transactions against official node to ensure exact match (especially `requestId`, `ticketId`, `maxRefund` calculation)
- [ ] **Retry transaction accuracy**: Verify the Retry transaction field calculations (particularly `max_refund = max_fee_per_gas * gas`) match Nitro's logic exactly
- [ ] **Regression testing**: Test other transaction types still serialize correctly and no existing functionality is broken

### Notes

**Link to Devin run**: https://app.devin.ai/sessions/4680efe5c87a444a8dcb08c035e7aa36  
**Requested by**: @tiljrd

**⚠️ Important**: This PR includes hardcoded assumptions about retry transaction construction (nonce: 0, specific field mappings) that were derived from analyzing official RPC output but not cross-verified with Nitro source code. The transaction ordering (Retry immediately after SubmitRetryable) also needs verification.