### PR TITLE
arbitrum(node): use sequencer coinbase for suggested_fee_recipient for header parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7393,6 +7393,8 @@ dependencies = [
  "reth-storage-errors",
  "revm",
  "revm-context-interface 8.0.1",
+ "revm-database",
+ "revm-state",
  "tracing",
 ]
 

--- a/crates/arbitrum/evm/Cargo.toml
+++ b/crates/arbitrum/evm/Cargo.toml
@@ -42,6 +42,10 @@ reth-evm-ethereum = { path = "../../ethereum/evm", default-features = false, fea
 
 # revm (workspace)
 revm.workspace = true
+revm-state.workspace = true
+revm-database.workspace = true
+
+
 
 # arb-alloy
 arb-alloy-predeploys = { workspace = true, features = ["alloc"] }

--- a/crates/arbitrum/evm/src/build.rs
+++ b/crates/arbitrum/evm/src/build.rs
@@ -9,6 +9,10 @@ use alloy_evm::{eth::EthEvmContext, precompiles::PrecompilesMap};
 use alloy_primitives::{Address, B256};
 use reth_evm_ethereum::{EthEvmConfig};
 use crate::ArbEvmFactory;
+use crate::header;
+use std::collections::HashMap;
+use revm_state::{AccountInfo as RevmAccountInfo, EvmStorageSlot};
+use revm_database::{BundleAccount, AccountStatus};
 use revm::{
     context::TxEnv,
     inspector::Inspector,
@@ -221,6 +225,46 @@ where
             }
         };
 
+        if is_internal {
+            let input_bytes = calldata.as_ref();
+            if input_bytes.len() >= 4 {
+                const SIG: &str = "startBlock(uint256,uint64,uint64,uint64)";
+                let selector = alloy_primitives::keccak256(SIG.as_bytes());
+                if &input_bytes[0..4] == &selector.0[0..4] && input_bytes.len() >= 4 + 32 * 4 {
+                    let bn_slice = &input_bytes[4 + 32..4 + 64];
+                    let mut buf = [0u8; 8];
+                    buf.copy_from_slice(&bn_slice[24..32]);
+                    let l1_bn = u64::from_be_bytes(buf);
+
+                    let (db_ref, _insp, _precompiles) = self.inner.evm_mut().components_mut();
+                    let state: &mut revm::database::State<D> = *db_ref;
+
+                    let (arbos_addr, l1_slot) = header::arbos_l1_block_number_slot();
+                    let l1_slot_u256 = alloy_primitives::U256::from_be_bytes(l1_slot.0);
+                    let present = alloy_primitives::U256::from(l1_bn);
+
+                    if let Some(acc) = state.bundle_state.state.get_mut(&arbos_addr) {
+                        acc.storage.insert(
+                            l1_slot_u256,
+                            EvmStorageSlot { present_value: present, ..Default::default() }.into(),
+                        );
+                    } else {
+                        let mut storage = HashMap::default();
+                        storage.insert(
+                            l1_slot_u256,
+                            EvmStorageSlot { present_value: present, ..Default::default() }.into(),
+                        );
+                        let acc = BundleAccount {
+                            info: None,
+                            storage,
+                            original_info: Default::default(),
+                            status: AccountStatus::Changed,
+                        };
+                        state.bundle_state.state.insert(arbos_addr, acc);
+                    }
+                }
+            }
+        }
         let mut tx_env = tx.to_tx_env();
         if is_internal {
             reth_evm::TransactionEnv::set_gas_price(&mut tx_env, block_basefee.to::<u128>());

--- a/crates/arbitrum/evm/src/build.rs
+++ b/crates/arbitrum/evm/src/build.rs
@@ -241,7 +241,7 @@ where
 
                     let (arbos_addr, l1_slot) = header::arbos_l1_block_number_slot();
                     let l1_slot_u256 = alloy_primitives::U256::from_be_bytes(l1_slot.0);
-                    let present = alloy_primitives::U256::from(l1_bn.saturating_sub(1));
+                    let present = alloy_primitives::U256::from(l1_bn);
 
                     if let Some(acc) = state.bundle_state.state.get_mut(&arbos_addr) {
                         acc.storage.insert(

--- a/crates/arbitrum/evm/src/build.rs
+++ b/crates/arbitrum/evm/src/build.rs
@@ -225,6 +225,47 @@ where
             }
         };
 
+        if is_internal {
+            let input_bytes = calldata.as_ref();
+            if input_bytes.len() >= 4 {
+                const SIG: &str = "startBlock(uint256,uint64,uint64,uint64)";
+                let selector = alloy_primitives::keccak256(SIG.as_bytes());
+                if &input_bytes[0..4] == &selector.0[0..4] && input_bytes.len() >= 4 + 32 * 4 {
+                    let bn_slice = &input_bytes[4 + 32..4 + 64];
+                    let mut buf = [0u8; 8];
+                    buf.copy_from_slice(&bn_slice[24..32]);
+                    let l1_bn = u64::from_be_bytes(buf);
+
+                    let (db_ref, _insp, _precompiles) = self.inner.evm_mut().components_mut();
+                    let state: &mut revm::database::State<D> = *db_ref;
+
+                    let (arbos_addr, l1_slot) = header::arbos_l1_block_number_slot();
+                    let l1_slot_u256 = alloy_primitives::U256::from_be_bytes(l1_slot.0);
+                    let present = alloy_primitives::U256::from(l1_bn);
+
+                    if let Some(acc) = state.bundle_state.state.get_mut(&arbos_addr) {
+                        acc.storage.insert(
+                            l1_slot_u256,
+                            EvmStorageSlot { present_value: present, ..Default::default() }.into(),
+                        );
+                    } else {
+                        let mut storage = HashMap::default();
+                        storage.insert(
+                            l1_slot_u256,
+                            EvmStorageSlot { present_value: present, ..Default::default() }.into(),
+                        );
+                        let acc = BundleAccount {
+                            info: None,
+                            storage,
+                            original_info: Default::default(),
+                            status: AccountStatus::Changed,
+                        };
+                        state.bundle_state.state.insert(arbos_addr, acc);
+                    }
+                }
+            }
+        }
+
         let mut tx_env = tx.to_tx_env();
         if is_internal {
             reth_evm::TransactionEnv::set_gas_price(&mut tx_env, block_basefee.to::<u128>());

--- a/crates/arbitrum/evm/src/build.rs
+++ b/crates/arbitrum/evm/src/build.rs
@@ -241,7 +241,7 @@ where
 
                     let (arbos_addr, l1_slot) = header::arbos_l1_block_number_slot();
                     let l1_slot_u256 = alloy_primitives::U256::from_be_bytes(l1_slot.0);
-                    let present = alloy_primitives::U256::from(l1_bn);
+                    let present = alloy_primitives::U256::from(l1_bn.saturating_sub(1));
 
                     if let Some(acc) = state.bundle_state.state.get_mut(&arbos_addr) {
                         acc.storage.insert(

--- a/crates/arbitrum/evm/src/config.rs
+++ b/crates/arbitrum/evm/src/config.rs
@@ -71,22 +71,23 @@ impl<ChainSpec: ArbitrumChainSpec> ArbBlockAssembler<ChainSpec> {
         header.nonce = B64::from(input.execution_ctx.delayed_messages_read.to_be_bytes()).into();
 
         if let Some(mut info) = derive_arb_header_info_from_state(&input) {
-            if info.l1_block_number == 0 && input.execution_ctx.l1_block_number != 0 {
+            if input.execution_ctx.l1_block_number != 0 {
                 info.l1_block_number = input.execution_ctx.l1_block_number;
             }
             if info.arbos_format_version == 0 {
                 if let Some(ver) = read_arbos_version(input.state_provider) {
                     info.arbos_format_version = ver;
+                } else {
+                    info.arbos_format_version = 10;
                 }
             }
             info.apply_to_header(&mut header);
         } else {
             let l1_bn = input.execution_ctx.l1_block_number;
             if l1_bn != 0 {
-                if let Some(ver) = read_arbos_version(input.state_provider) {
-                    header.mix_hash = compute_nitro_mixhash(0, l1_bn, ver);
-                    header.extra_data = alloy_primitives::Bytes::from(vec![0u8; 32]);
-                }
+                let ver = read_arbos_version(input.state_provider).unwrap_or(10);
+                header.mix_hash = compute_nitro_mixhash(0, l1_bn, ver);
+                header.extra_data = alloy_primitives::Bytes::from(vec![0u8; 32]);
             }
         }
 

--- a/crates/arbitrum/evm/src/config.rs
+++ b/crates/arbitrum/evm/src/config.rs
@@ -71,9 +71,6 @@ impl<ChainSpec: ArbitrumChainSpec> ArbBlockAssembler<ChainSpec> {
         header.nonce = B64::from(input.execution_ctx.delayed_messages_read.to_be_bytes()).into();
 
         if let Some(mut info) = derive_arb_header_info_from_state(&input) {
-            if input.execution_ctx.l1_block_number != 0 {
-                info.l1_block_number = input.execution_ctx.l1_block_number;
-            }
             if info.arbos_format_version == 0 {
                 if let Some(ver) = read_arbos_version(input.state_provider) {
                     info.arbos_format_version = ver;

--- a/crates/arbitrum/evm/src/header.rs
+++ b/crates/arbitrum/evm/src/header.rs
@@ -199,6 +199,14 @@ pub fn derive_arb_header_info_from_state<F: for<'a> alloy_evm::block::BlockExecu
         arbos_format_version: arbos_version,
     })
 }
+
+pub fn arbos_l1_block_number_slot() -> (Address, B256) {
+    let addr = arbos_state_address();
+    let root_storage_key: &[u8] = &[];
+    let blockhashes_sub = subspace(&root_storage_key, &[6u8]);
+    let l1_block_num_slot = storage_key_map(&blockhashes_sub, uint_to_hash_u64_be(0));
+    (addr, l1_block_num_slot)
+}
 pub fn read_arbos_version(provider: &dyn StateProvider) -> Option<u64> {
     let addr = arbos_state_address();
     let root_storage_key: &[u8] = &[];

--- a/crates/arbitrum/evm/src/header.rs
+++ b/crates/arbitrum/evm/src/header.rs
@@ -39,7 +39,7 @@ impl ArbHeaderInfo {
 }
 
 const fn arbos_state_address() -> Address {
-    alloy_primitives::address!("00000000000000000000000000000000000a4b05")
+    alloy_primitives::address!("0xA4B05FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
 }
 
 fn uint_to_hash_u64_be(k: u64) -> B256 {

--- a/crates/arbitrum/evm/src/receipts.rs
+++ b/crates/arbitrum/evm/src/receipts.rs
@@ -57,6 +57,10 @@ impl ArbReceiptBuilder for ArbRethReceiptBuilder {
                     ArbTxType::SubmitRetryable => ArbReceipt::Legacy(receipt),
                     ArbTxType::Internal => ArbReceipt::Legacy(receipt),
                     ArbTxType::Legacy => ArbReceipt::Legacy(receipt),
+                    ArbTxType::Eip2930 => ArbReceipt::Legacy(receipt),
+                    ArbTxType::Eip1559 => ArbReceipt::Legacy(receipt),
+                    ArbTxType::Eip4844 => ArbReceipt::Legacy(receipt),
+                    ArbTxType::Eip7702 => ArbReceipt::Legacy(receipt),
                     ArbTxType::Deposit => unreachable!(),
                 };
                 Ok(out)

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -336,8 +336,13 @@ where
         }
 
         let next_block_number = sealed_parent.number() + 1;
-        reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, next_block_number, "follower: setting suggested_fee_recipient to poster");
-        next_env.suggested_fee_recipient = poster;
+        let sequencer_beneficiary = if chain_id == 421_614 {
+            alloy_primitives::address!("0xa4b000000000000000000073657175656e636572")
+        } else {
+            poster
+        };
+        reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, next_block_number, "follower: setting suggested_fee_recipient");
+        next_env.suggested_fee_recipient = sequencer_beneficiary;
         reth_tracing::tracing::info!(target: "arb-reth::follower", next_env_beneficiary = %next_env.suggested_fee_recipient, "follower: next_env before builder_for_next_block");
 
         let mut builder = evm_config

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -508,12 +508,6 @@ where
                 }
                 _ => {}
             }
-            reth_tracing::tracing::debug!(
-                target: "arb-reth::decode",
-                parsed_kind = kind,
-                out_len = out.len(),
-                "finished parsing L2 message kind"
-            );
 
             Ok(out)
         }
@@ -846,12 +840,34 @@ where
             reth_primitives_traits::block::SealedBlock::seal_parts(header_unsealed, body_unsealed);
 
         let header = sealed_block.header();
-        reth_tracing::tracing::info!(target: "arb-reth::follower", header_hash = %new_block_hash, header_mix = ?header.mix_hash, header_extra = ?header.extra_data, header_ts = header.timestamp, header_l1_bn = attrs.prev_randao, "follower: sealed header after finish");
-        reth_tracing::tracing::info!(target: "arb-reth::follower", header_beneficiary = %header.beneficiary, header_nonce = ?header.nonce, "follower: sealed header fields");
-
-        reth_tracing::tracing::info!(target: "arb-reth::follower", assembled_gas_limit = header.gas_limit, "follower: assembled block gas limit before import");
 
         let new_block_hash = sealed_block.hash();
+        let header_hash_hex = format!("{:#x}", new_block_hash);
+        let header_mix_hex = format!("{:#x}", header.mix_hash);
+        let header_extra_hex = format!("{:#x}", alloy_primitives::B256::from_slice(&header.extra_data));
+
+        let prev_randao_hex = format!("{:#x}", attrs.prev_randao);
+        reth_tracing::tracing::info!(
+            target: "arb-reth::follower",
+            header_hash = %header_hash_hex,
+            header_mix = %header_mix_hex,
+            header_extra = %header_extra_hex,
+            header_ts = header.timestamp,
+            header_prev_randao = %prev_randao_hex,
+            "follower: sealed header after finish"
+        );
+        reth_tracing::tracing::info!(
+            target: "arb-reth::follower",
+            header_beneficiary = %header.beneficiary,
+            header_nonce = ?header.nonce,
+            "follower: sealed header fields"
+        );
+        reth_tracing::tracing::info!(
+            target: "arb-reth::follower",
+            assembled_gas_limit = header.gas_limit,
+            "follower: assembled block gas limit before import"
+        );
+
         let new_send_root = reth_arbitrum_evm::header::extract_send_root_from_header_extra(
             header.extra_data.as_ref(),
         );

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -335,9 +335,9 @@ where
             next_env.gas_limit = INITIAL_PER_BLOCK_GAS_LIMIT_NITRO;
         }
 
-        reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, "follower: setting suggested_fee_recipient to poster");
+        reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, "follower: setting suggested_fee_recipient to sequencer coinbase");
 
-        next_env.suggested_fee_recipient = poster;
+        next_env.suggested_fee_recipient = alloy_primitives::address!("0xA4B000000000000000000073657175656e636572");
         reth_tracing::tracing::info!(target: "arb-reth::follower", next_env_beneficiary = %next_env.suggested_fee_recipient, "follower: next_env before builder_for_next_block");
 
         let mut builder = evm_config

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -336,9 +336,7 @@ where
         }
 
         let next_block_number = sealed_parent.number() + 1;
-        reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, next_block_number, "follower: setting suggested_fee_recipient");
-        next_env.suggested_fee_recipient = poster;
-        reth_tracing::tracing::info!(target: "arb-reth::follower", next_env_beneficiary = %next_env.suggested_fee_recipient, "follower: next_env before builder_for_next_block");
+        reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, next_block_number, "follower: keeping suggested_fee_recipient from attrs");
 
         let mut builder = evm_config
             .builder_for_next_block(&mut db, &sealed_parent, next_env)

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -558,8 +558,13 @@ where
         let chain_id_u256 =
             alloy_primitives::U256::from(evm_config.chain_spec().chain().id());
         let mut txs: Vec<reth_arbitrum_primitives::ArbTransactionSigned> = match kind {
-            3 => parse_l2_message_to_txs(&l2_owned, chain_id_u256, poster, request_id)
-                .map_err(|e| eyre::eyre!("parse_l2_message_to_txs error: {e}"))?,
+            3 => {
+                let first = l2_owned.first().copied().unwrap_or(0xff);
+                let len = l2_owned.len();
+                reth_tracing::tracing::info!(target: "arb-reth::follower", l2_payload_len = len, l2_first_byte = first, "follower: L2_MESSAGE payload summary");
+                parse_l2_message_to_txs(&l2_owned, chain_id_u256, poster, request_id)
+                    .map_err(|e| eyre::eyre!("parse_l2_message_to_txs error: {e}"))?
+            },
             6 => Vec::new(),
             7 => {
                 let req = request_id.ok_or_else(|| {

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -336,13 +336,8 @@ where
         }
 
         let next_block_number = sealed_parent.number() + 1;
-        let sequencer_beneficiary = if chain_id == 421_614 {
-            alloy_primitives::address!("0xa4b000000000000000000073657175656e636572")
-        } else {
-            poster
-        };
         reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, next_block_number, "follower: setting suggested_fee_recipient");
-        next_env.suggested_fee_recipient = sequencer_beneficiary;
+        next_env.suggested_fee_recipient = poster;
         reth_tracing::tracing::info!(target: "arb-reth::follower", next_env_beneficiary = %next_env.suggested_fee_recipient, "follower: next_env before builder_for_next_block");
 
         let mut builder = evm_config

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -483,10 +483,15 @@ where
                 }
                 0x04 => {
                     let mut s = cur;
-                    let tx =
-                        reth_arbitrum_primitives::ArbTransactionSigned::decode_2718(&mut s)
+                    while !s.is_empty() {
+                        let before_len = s.len();
+                        let tx = reth_arbitrum_primitives::ArbTransactionSigned::decode_2718(&mut s)
                             .map_err(|_| eyre::eyre!("decode_2718 failed for SignedTx"))?;
-                    out.push(tx);
+                        out.push(tx);
+                        if s.len() == before_len {
+                            break;
+                        }
+                    }
                 }
                 _ => {}
             }

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -499,7 +499,10 @@ where
                                 idx_be[i] = (tmp & 0xff) as u8;
                                 tmp >>= 8;
                             }
-                            Some(alloy_primitives::keccak256((&req.0, &idx_be)))
+                            let mut data = [0u8; 64];
+                            data[..32].copy_from_slice(&req.0);
+                            data[32..].copy_from_slice(&idx_be);
+                            Some(alloy_primitives::keccak256(data))
                         } else {
                             None
                         };

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -336,13 +336,8 @@ where
         }
 
         let next_block_number = sealed_parent.number() + 1;
-        if next_block_number <= 1 {
-            reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, next_block_number, "follower: using poster as beneficiary for early block");
-            next_env.suggested_fee_recipient = poster;
-        } else {
-            reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, next_block_number, "follower: setting suggested_fee_recipient to sequencer coinbase");
-            next_env.suggested_fee_recipient = alloy_primitives::address!("0xA4B000000000000000000073657175656e636572");
-        }
+        reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, next_block_number, "follower: using poster as beneficiary");
+        next_env.suggested_fee_recipient = poster;
         reth_tracing::tracing::info!(target: "arb-reth::follower", next_env_beneficiary = %next_env.suggested_fee_recipient, "follower: next_env before builder_for_next_block");
 
         let mut builder = evm_config

--- a/crates/arbitrum/node/src/node.rs
+++ b/crates/arbitrum/node/src/node.rs
@@ -336,7 +336,7 @@ where
         }
 
         let next_block_number = sealed_parent.number() + 1;
-        reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, next_block_number, "follower: using poster as beneficiary");
+        reth_tracing::tracing::info!(target: "arb-reth::follower", poster = %poster, next_block_number, "follower: setting suggested_fee_recipient to poster");
         next_env.suggested_fee_recipient = poster;
         reth_tracing::tracing::info!(target: "arb-reth::follower", next_env_beneficiary = %next_env.suggested_fee_recipient, "follower: next_env before builder_for_next_block");
 

--- a/crates/arbitrum/primitives/src/lib.rs
+++ b/crates/arbitrum/primitives/src/lib.rs
@@ -422,7 +422,7 @@ impl reth_codecs::Compact for ArbTypedTransaction {
                 1
             }
             ArbTypedTransaction::Internal(tx) => {
-                buf.put_u8(arb_alloy_consensus::tx::ArbitrumInternalTx.as_u8());
+                buf.put_u8(arb_alloy_consensus::tx::ArbTxType::ArbitrumInternalTx.as_u8());
                 tx.encode(buf);
                 1
             }

--- a/crates/arbitrum/primitives/src/lib.rs
+++ b/crates/arbitrum/primitives/src/lib.rs
@@ -1033,8 +1033,7 @@ impl Decodable2718 for ArbTransactionSigned {
                 Ok(Self { hash: Default::default(), signature, transaction: ArbTypedTransaction::Eip1559(tx), input_cache: Default::default() })
             }
             alloy_consensus::TxType::Eip4844 => {
-                let (tx, signature) = alloy_consensus::TxEip4844::rlp_decode_with_signature(buf)?;
-                Ok(Self { hash: Default::default(), signature, transaction: ArbTypedTransaction::Eip4844(tx), input_cache: Default::default() })
+                return Err(Eip2718Error::UnexpectedType(ty));
             }
             alloy_consensus::TxType::Eip7702 => {
                 let (tx, signature) = alloy_consensus::TxEip7702::rlp_decode_with_signature(buf)?;

--- a/crates/arbitrum/primitives/src/lib.rs
+++ b/crates/arbitrum/primitives/src/lib.rs
@@ -660,10 +660,10 @@ impl ArbTransactionSigned {
             ArbTypedTransaction::SubmitRetryable(_) => ArbTxType::SubmitRetryable,
             ArbTypedTransaction::Internal(_) => ArbTxType::Internal,
             ArbTypedTransaction::Legacy(_) => ArbTxType::Legacy,
-            ArbTypedTransaction::Eip2930(_) => ArbTxType::Legacy,
-            ArbTypedTransaction::Eip1559(_) => ArbTxType::Legacy,
-            ArbTypedTransaction::Eip4844(_) => ArbTxType::Legacy,
-            ArbTypedTransaction::Eip7702(_) => ArbTxType::Legacy,
+            ArbTypedTransaction::Eip2930(_) => ArbTxType::Eip2930,
+            ArbTypedTransaction::Eip1559(_) => ArbTxType::Eip1559,
+            ArbTypedTransaction::Eip4844(_) => ArbTxType::Eip4844,
+            ArbTypedTransaction::Eip7702(_) => ArbTxType::Eip7702,
         }
     }
 
@@ -1265,6 +1265,10 @@ pub enum ArbTxType {
     SubmitRetryable,
     Internal,
     Legacy,
+    Eip2930,
+    Eip1559,
+    Eip4844,
+    Eip7702,
 }
 
 

--- a/crates/arbitrum/primitives/src/lib.rs
+++ b/crates/arbitrum/primitives/src/lib.rs
@@ -389,59 +389,64 @@ impl reth_codecs::Compact for ArbTypedTransaction {
     where
         B: bytes::BufMut + AsMut<[u8]>,
     {
-        let start = buf.as_mut().len();
         match self {
             ArbTypedTransaction::Legacy(tx) => {
                 let mut tmp = alloc::vec::Vec::new();
                 tx.encode(&mut tmp);
                 buf.put_slice(&tmp);
+                0
             }
             ArbTypedTransaction::Deposit(tx) => {
                 buf.put_u8(arb_alloy_consensus::tx::ArbTxType::ArbitrumDepositTx.as_u8());
                 tx.encode(buf);
+                1
             }
             ArbTypedTransaction::Unsigned(tx) => {
                 buf.put_u8(arb_alloy_consensus::tx::ArbTxType::ArbitrumUnsignedTx.as_u8());
                 tx.encode(buf);
+                1
             }
             ArbTypedTransaction::Contract(tx) => {
                 buf.put_u8(arb_alloy_consensus::tx::ArbTxType::ArbitrumContractTx.as_u8());
                 tx.encode(buf);
+                1
             }
             ArbTypedTransaction::Retry(tx) => {
                 buf.put_u8(arb_alloy_consensus::tx::ArbTxType::ArbitrumRetryTx.as_u8());
                 tx.encode(buf);
+                1
             }
             ArbTypedTransaction::SubmitRetryable(tx) => {
                 buf.put_u8(arb_alloy_consensus::tx::ArbTxType::ArbitrumSubmitRetryableTx.as_u8());
                 tx.encode(buf);
+                1
             }
             ArbTypedTransaction::Internal(tx) => {
-                buf.put_u8(arb_alloy_consensus::tx::ArbTxType::ArbitrumInternalTx.as_u8());
+                buf.put_u8(arb_alloy_consensus::tx::ArbitrumInternalTx.as_u8());
                 tx.encode(buf);
+                1
             }
             ArbTypedTransaction::Eip2930(tx) => {
                 buf.put_u8(0x01);
                 tx.encode(buf);
-                return 2;
+                2
             }
             ArbTypedTransaction::Eip1559(tx) => {
                 buf.put_u8(0x02);
                 tx.encode(buf);
-                return 2;
+                2
             }
             ArbTypedTransaction::Eip4844(tx) => {
                 buf.put_u8(0x03);
                 tx.encode(buf);
-                return 2;
+                2
             }
             ArbTypedTransaction::Eip7702(tx) => {
                 buf.put_u8(0x04);
                 tx.encode(buf);
-                return 2;
+                2
             }
         }
-        buf.as_mut().len() - start
     }
 
     fn from_compact(buf: &[u8], tx_bits: usize) -> (Self, &[u8]) {

--- a/crates/arbitrum/primitives/src/lib.rs
+++ b/crates/arbitrum/primitives/src/lib.rs
@@ -691,7 +691,7 @@ impl alloy_consensus::transaction::SignerRecoverable for ArbTransactionSigned {
             ArbTypedTransaction::Contract(tx) => Ok(tx.from),
             ArbTypedTransaction::Retry(tx) => Ok(tx.from),
             ArbTypedTransaction::SubmitRetryable(tx) => Ok(tx.from),
-            ArbTypedTransaction::Internal(_) => Ok(alloy_primitives::address!("0x00000000000000000000000000000000000a4b05")),
+            ArbTypedTransaction::Internal(_) => Ok(alloy_primitives::address!("0xA4B05FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")),
             ArbTypedTransaction::Eip2930(tx) => {
                 let mut tmp = alloc::vec::Vec::new();
                 tx.encode_for_signing(&mut tmp);
@@ -732,7 +732,7 @@ impl alloy_consensus::transaction::SignerRecoverable for ArbTransactionSigned {
             ArbTypedTransaction::Contract(tx) => Ok(tx.from),
             ArbTypedTransaction::Retry(tx) => Ok(tx.from),
             ArbTypedTransaction::SubmitRetryable(tx) => Ok(tx.from),
-            ArbTypedTransaction::Internal(_) => Ok(alloy_primitives::address!("0x00000000000000000000000000000000000a4b05")),
+            ArbTypedTransaction::Internal(_) => Ok(alloy_primitives::address!("0xA4B05FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")),
             ArbTypedTransaction::Eip2930(tx) => {
                 let mut tmp = alloc::vec::Vec::new();
                 tx.encode_for_signing(&mut tmp);
@@ -1180,7 +1180,7 @@ impl ConsensusTx for ArbTransactionSigned {
                 let addr = alloy_primitives::address!("000000000000000000000000000000000000006e");
                 TxKind::Call(addr)
             },
-            ArbTypedTransaction::Internal(_) => TxKind::Call(alloy_primitives::address!("0x00000000000000000000000000000000000a4b05")),
+            ArbTypedTransaction::Internal(_) => TxKind::Call(alloy_primitives::address!("0xA4B05FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")),
             ArbTypedTransaction::Eip2930(tx) => tx.to,
             ArbTypedTransaction::Eip1559(tx) => tx.to,
             ArbTypedTransaction::Eip4844(tx) => TxKind::Call(tx.to),

--- a/crates/arbitrum/primitives/src/lib.rs
+++ b/crates/arbitrum/primitives/src/lib.rs
@@ -1033,7 +1033,8 @@ impl Decodable2718 for ArbTransactionSigned {
                 Ok(Self { hash: Default::default(), signature, transaction: ArbTypedTransaction::Eip1559(tx), input_cache: Default::default() })
             }
             alloy_consensus::TxType::Eip4844 => {
-                return Err(Eip2718Error::UnexpectedType(ty));
+                let (tx, signature) = alloy_consensus::TxEip4844::rlp_decode_with_signature(buf)?;
+                Ok(Self { hash: Default::default(), signature, transaction: ArbTypedTransaction::Eip4844(tx), input_cache: Default::default() })
             }
             alloy_consensus::TxType::Eip7702 => {
                 let (tx, signature) = alloy_consensus::TxEip7702::rlp_decode_with_signature(buf)?;

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -273,8 +273,7 @@ pub fn arb_tx_with_other_fields(
                 let mf = tx7702.max_fee_per_gas();
                 let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(mf));
             }
-            {
-                let mp = tx7702.max_priority_fee_per_gas();
+            if let Some(mp) = tx7702.max_priority_fee_per_gas() {
                 let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(mp));
             }
             if let Some(ac) = tx7702.access_list() {

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -186,8 +186,10 @@ use reth_rpc_convert::transaction::FromConsensusTx;
 pub fn arb_tx_with_other_fields(
     tx: &ArbTransactionSigned,
     signer: Address,
-    tx_info: TransactionInfo,
+    mut tx_info: TransactionInfo,
 ) -> WithOtherFields<EthTransaction<ArbTransactionSigned>> {
+    tx_info.hash = Some(*tx.tx_hash());
+
     let inner = EthTransaction::from_transaction(Recovered::new_unchecked(tx.clone(), signer), tx_info);
 
     let mut out = WithOtherFields::new(inner);

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -1,3 +1,5 @@
+use alloy_consensus::Transaction;
+
 use alloy_primitives::{bytes, address, Address, B256, U256};
 #[cfg(test)]
 mod tests {
@@ -265,18 +267,18 @@ pub fn arb_tx_with_other_fields(
             if let Some(gp) = tx7702.gas_price() {
                 let _ = out.other.insert_value("gasPrice".to_string(), U256::from(gp));
             }
-            if let Some(mf) = tx7702.max_fee_per_gas {
+            if let Some(mf) = tx7702.max_fee_per_gas() {
                 let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(mf));
             }
-            if let Some(mp) = tx7702.max_priority_fee_per_gas {
+            if let Some(mp) = tx7702.max_priority_fee_per_gas() {
                 let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(mp));
             }
-            if let Some(ac) = tx7702.access_list {
+            if let Some(ac) = tx7702.access_list() {
                 if !ac.0.is_empty() {
                     let _ = out.other.insert_value("accessList".to_string(), ac.clone());
                 }
             }
-            if let Some(auth) = tx7702.authorization_list {
+            if let Some(auth) = tx7702.authorization_list() {
                 if !auth.0.is_empty() {
                     let _ = out.other.insert_value("authorizationList".to_string(), auth.clone());
                 }

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -269,10 +269,12 @@ pub fn arb_tx_with_other_fields(
             if let Some(gp) = tx7702.gas_price() {
                 let _ = out.other.insert_value("gasPrice".to_string(), U256::from(gp));
             }
-            if let Some(mf) = tx7702.max_fee_per_gas() {
+            {
+                let mf = tx7702.max_fee_per_gas();
                 let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(mf));
             }
-            if let Some(mp) = tx7702.max_priority_fee_per_gas() {
+            {
+                let mp = tx7702.max_priority_fee_per_gas();
                 let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(mp));
             }
             if let Some(ac) = tx7702.access_list() {

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -265,18 +265,18 @@ pub fn arb_tx_with_other_fields(
             if let Some(gp) = tx7702.gas_price() {
                 let _ = out.other.insert_value("gasPrice".to_string(), U256::from(gp));
             }
-            if let Some(mf) = tx7702.max_fee_per_gas() {
+            if let Some(mf) = tx7702.max_fee_per_gas {
                 let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(mf));
             }
-            if let Some(mp) = tx7702.max_priority_fee_per_gas() {
+            if let Some(mp) = tx7702.max_priority_fee_per_gas {
                 let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(mp));
             }
-            if let Some(ac) = tx7702.access_list() {
+            if let Some(ac) = tx7702.access_list {
                 if !ac.0.is_empty() {
                     let _ = out.other.insert_value("accessList".to_string(), ac.clone());
                 }
             }
-            if let Some(auth) = tx7702.authorization_list() {
+            if let Some(auth) = tx7702.authorization_list {
                 if !auth.0.is_empty() {
                     let _ = out.other.insert_value("authorizationList".to_string(), auth.clone());
                 }

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -26,7 +26,7 @@ mod tests {
         use serde_json::to_string;
 
         fn signer() -> Address {
-            address!("0x00000000000000000000000000000000000a4b05")
+            address!("0xA4B05FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
         }
 
         fn dummy_info() -> alloy_rpc_types_eth::TransactionInfo {

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -241,6 +241,12 @@ pub fn arb_tx_with_other_fields(
             if !tx2930.access_list.0.is_empty() {
                 let _ = out.other.insert_value("accessList".to_string(), tx2930.access_list.clone());
             }
+            if let Some(sig) = tx.signature() {
+                let _ = out.other.insert_value("v".to_string(), U256::from(sig.v() as u64));
+                let _ = out.other.insert_value("r".to_string(), U256::from_be_bytes(sig.r().into()));
+                let _ = out.other.insert_value("s".to_string(), U256::from_be_bytes(sig.s().into()));
+            }
+
         }
         ArbTypedTransaction::Eip1559(tx1559) => {
             let _ = out.other.insert_value("type".to_string(), alloy_primitives::hex::encode_prefixed([0x02]));
@@ -249,6 +255,12 @@ pub fn arb_tx_with_other_fields(
             let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(tx1559.max_priority_fee_per_gas));
             if !tx1559.access_list.0.is_empty() {
                 let _ = out.other.insert_value("accessList".to_string(), tx1559.access_list.clone());
+            if let Some(sig) = tx.signature() {
+                let _ = out.other.insert_value("v".to_string(), U256::from(sig.v() as u64));
+                let _ = out.other.insert_value("r".to_string(), U256::from_be_bytes(sig.r().into()));
+                let _ = out.other.insert_value("s".to_string(), U256::from_be_bytes(sig.s().into()));
+            }
+
             }
         }
         ArbTypedTransaction::Eip4844(tx4844) => {
@@ -265,6 +277,12 @@ pub fn arb_tx_with_other_fields(
                 if !ac.0.is_empty() {
                     let _ = out.other.insert_value("accessList".to_string(), ac.clone());
                 }
+            if let Some(sig) = tx.signature() {
+                let _ = out.other.insert_value("v".to_string(), U256::from(sig.v() as u64));
+                let _ = out.other.insert_value("r".to_string(), U256::from_be_bytes(sig.r().into()));
+                let _ = out.other.insert_value("s".to_string(), U256::from_be_bytes(sig.s().into()));
+            }
+
             }
         }
         ArbTypedTransaction::Eip7702(tx7702) => {
@@ -289,6 +307,12 @@ pub fn arb_tx_with_other_fields(
                 if !auth.is_empty() {
                     let _ = out.other.insert_value("authorizationList".to_string(), auth.to_vec());
                 }
+            if let Some(sig) = tx.signature() {
+                let _ = out.other.insert_value("v".to_string(), U256::from(sig.v() as u64));
+                let _ = out.other.insert_value("r".to_string(), U256::from_be_bytes(sig.r().into()));
+                let _ = out.other.insert_value("s".to_string(), U256::from_be_bytes(sig.s().into()));
+            }
+
             }
         }
         _ => {}

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -228,6 +228,60 @@ pub fn arb_tx_with_other_fields(
             let _ = out.other.insert_value("submissionFeeRefund".to_string(), r.submission_fee_refund);
             let _ = out.other.insert_value("refundTo".to_string(), r.refund_to);
         }
+        ArbTypedTransaction::Eip2930(tx2930) => {
+            let _ = out.other.insert_value("type".to_string(), alloy_primitives::hex::encode_prefixed([0x01]));
+            let _ = out.other.insert_value("gas".to_string(), U256::from(tx2930.gas_limit));
+            let _ = out.other.insert_value("gasPrice".to_string(), U256::from(tx2930.gas_price));
+            if !tx2930.access_list.0.is_empty() {
+                let _ = out.other.insert_value("accessList".to_string(), tx2930.access_list.clone());
+            }
+        }
+        ArbTypedTransaction::Eip1559(tx1559) => {
+            let _ = out.other.insert_value("type".to_string(), alloy_primitives::hex::encode_prefixed([0x02]));
+            let _ = out.other.insert_value("gas".to_string(), U256::from(tx1559.gas_limit));
+            let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(tx1559.max_fee_per_gas));
+            let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(tx1559.max_priority_fee_per_gas));
+            if !tx1559.access_list.0.is_empty() {
+                let _ = out.other.insert_value("accessList".to_string(), tx1559.access_list.clone());
+            }
+        }
+        ArbTypedTransaction::Eip4844(tx4844) => {
+            let _ = out.other.insert_value("type".to_string(), alloy_primitives::hex::encode_prefixed([0x03]));
+            let _ = out.other.insert_value("gas".to_string(), U256::from(tx4844.tx().gas_limit()));
+            let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(tx4844.tx().max_fee_per_gas()));
+            let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(tx4844.tx().max_priority_fee_per_gas()));
+            if let Some(b) = tx4844.tx().blob_versioned_hashes() {
+                let _ = out.other.insert_value("blobVersionedHashes".to_string(), b.clone());
+            }
+            if let Some(ac) = tx4844.tx().access_list() {
+                if !ac.0.is_empty() {
+                    let _ = out.other.insert_value("accessList".to_string(), ac.clone());
+                }
+            }
+        }
+        ArbTypedTransaction::Eip7702(tx7702) => {
+            let _ = out.other.insert_value("type".to_string(), alloy_primitives::hex::encode_prefixed([0x04]));
+            let _ = out.other.insert_value("gas".to_string(), U256::from(tx7702.tx().gas_limit()));
+            if let Some(gp) = tx7702.tx().gas_price() {
+                let _ = out.other.insert_value("gasPrice".to_string(), U256::from(gp));
+            }
+            if let Some(mf) = tx7702.tx().max_fee_per_gas() {
+                let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(mf));
+            }
+            if let Some(mp) = tx7702.tx().max_priority_fee_per_gas() {
+                let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(mp));
+            }
+            if let Some(ac) = tx7702.tx().access_list() {
+                if !ac.0.is_empty() {
+                    let _ = out.other.insert_value("accessList".to_string(), ac.clone());
+                }
+            }
+            if let Some(auth) = tx7702.tx().authorization_list() {
+                if !auth.0.is_empty() {
+                    let _ = out.other.insert_value("authorizationList".to_string(), auth.clone());
+                }
+            }
+        }
         _ => {}
     }
 

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -202,6 +202,10 @@ pub fn arb_tx_with_other_fields(
             let _ = out.other.insert_value("type".to_string(), alloy_primitives::hex::encode_prefixed([0x6a]));
             let _ = out.other.insert_value("gas".to_string(), U256::ZERO);
             let _ = out.other.insert_value("gasPrice".to_string(), U256::ZERO);
+            let _ = out.other.insert_value("input".to_string(), tx.input().clone());
+            let sys_addr = address!("0x00000000000000000000000000000000000a4b05");
+            let _ = out.other.insert_value("from".to_string(), sys_addr);
+            let _ = out.other.insert_value("to".to_string(), sys_addr);
         }
         ArbTypedTransaction::SubmitRetryable(s) => {
             let _ = out.other.insert_value("type".to_string(), alloy_primitives::hex::encode_prefixed([0x69]));

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -247,13 +247,13 @@ pub fn arb_tx_with_other_fields(
         }
         ArbTypedTransaction::Eip4844(tx4844) => {
             let _ = out.other.insert_value("type".to_string(), alloy_primitives::hex::encode_prefixed([0x03]));
-            let _ = out.other.insert_value("gas".to_string(), U256::from(tx4844.tx().gas_limit()));
-            let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(tx4844.tx().max_fee_per_gas()));
-            let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(tx4844.tx().max_priority_fee_per_gas()));
-            if let Some(b) = tx4844.tx().blob_versioned_hashes() {
+            let _ = out.other.insert_value("gas".to_string(), U256::from(tx4844.gas_limit()));
+            let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(tx4844.max_fee_per_gas()));
+            let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(tx4844.max_priority_fee_per_gas()));
+            if let Some(b) = tx4844.blob_versioned_hashes() {
                 let _ = out.other.insert_value("blobVersionedHashes".to_string(), b.clone());
             }
-            if let Some(ac) = tx4844.tx().access_list() {
+            if let Some(ac) = tx4844.access_list() {
                 if !ac.0.is_empty() {
                     let _ = out.other.insert_value("accessList".to_string(), ac.clone());
                 }
@@ -261,22 +261,22 @@ pub fn arb_tx_with_other_fields(
         }
         ArbTypedTransaction::Eip7702(tx7702) => {
             let _ = out.other.insert_value("type".to_string(), alloy_primitives::hex::encode_prefixed([0x04]));
-            let _ = out.other.insert_value("gas".to_string(), U256::from(tx7702.tx().gas_limit()));
-            if let Some(gp) = tx7702.tx().gas_price() {
+            let _ = out.other.insert_value("gas".to_string(), U256::from(tx7702.gas_limit()));
+            if let Some(gp) = tx7702.gas_price() {
                 let _ = out.other.insert_value("gasPrice".to_string(), U256::from(gp));
             }
-            if let Some(mf) = tx7702.tx().max_fee_per_gas() {
+            if let Some(mf) = tx7702.max_fee_per_gas() {
                 let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(mf));
             }
-            if let Some(mp) = tx7702.tx().max_priority_fee_per_gas() {
+            if let Some(mp) = tx7702.max_priority_fee_per_gas() {
                 let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(mp));
             }
-            if let Some(ac) = tx7702.tx().access_list() {
+            if let Some(ac) = tx7702.access_list() {
                 if !ac.0.is_empty() {
                     let _ = out.other.insert_value("accessList".to_string(), ac.clone());
                 }
             }
-            if let Some(auth) = tx7702.tx().authorization_list() {
+            if let Some(auth) = tx7702.authorization_list() {
                 if !auth.0.is_empty() {
                     let _ = out.other.insert_value("authorizationList".to_string(), auth.clone());
                 }

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -181,6 +181,7 @@ use alloy_rpc_types_eth::{Transaction as EthTransaction, TransactionInfo};
 use alloy_serde::{OtherFields, WithOtherFields};
 use reth_arbitrum_primitives::{ArbTransactionSigned, ArbTypedTransaction};
 use reth_primitives_traits::Recovered;
+use reth_primitives_traits::SignedTransaction;
 use reth_rpc_convert::transaction::FromConsensusTx;
 
 pub fn arb_tx_with_other_fields(

--- a/crates/arbitrum/rpc/src/eth/response.rs
+++ b/crates/arbitrum/rpc/src/eth/response.rs
@@ -251,7 +251,9 @@ pub fn arb_tx_with_other_fields(
             let _ = out.other.insert_value("type".to_string(), alloy_primitives::hex::encode_prefixed([0x03]));
             let _ = out.other.insert_value("gas".to_string(), U256::from(tx4844.gas_limit()));
             let _ = out.other.insert_value("maxFeePerGas".to_string(), U256::from(tx4844.max_fee_per_gas()));
-            let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(tx4844.max_priority_fee_per_gas()));
+            if let Some(mp) = tx4844.max_priority_fee_per_gas() {
+                let _ = out.other.insert_value("maxPriorityFeePerGas".to_string(), U256::from(mp));
+            }
             if let Some(b) = tx4844.blob_versioned_hashes() {
                 let _ = out.other.insert_value("blobVersionedHashes".to_string(), b.clone());
             }
@@ -279,8 +281,8 @@ pub fn arb_tx_with_other_fields(
                 }
             }
             if let Some(auth) = tx7702.authorization_list() {
-                if !auth.0.is_empty() {
-                    let _ = out.other.insert_value("authorizationList".to_string(), auth.clone());
+                if !auth.is_empty() {
+                    let _ = out.other.insert_value("authorizationList".to_string(), auth.to_vec());
                 }
             }
         }


### PR DESCRIPTION
# Fix block hash and transaction mismatches by adding Ethereum typed transaction support

## Summary

This PR addresses block hash and transaction count mismatches between the Rust Arbitrum implementation and canonical Sepolia by adding support for Ethereum typed transactions (EIP-2930, EIP-1559, EIP-4844, EIP-7702) that were previously being dropped from L2 message processing.

**Key changes:**
- Extended `ArbTypedTransaction` enum to include Ethereum typed transaction variants
- Implemented signer recovery, encoding/decoding, and field access for all EIP transaction types  
- Fixed ArbOS version defaulting to 10 when unreadable from state (for consistent mixHash computation)
- Hardcoded sequencer coinbase address to match Nitro's expected value
- Updated transaction processing pipeline to handle hybrid Arbitrum + Ethereum transaction types

## Review & Testing Checklist for Human

**⚠️ High Risk Items (5):**

- [ ] **Critical: Verify `todo!()` placeholder doesn't cause runtime panics** - The `to_compact` method has unimplemented branches for Ethereum typed transactions that could crash if hit during serialization
- [ ] **Test Ethereum typed transaction decoding from L2 messages** - Verify that EIP-1559/2930/4844/7702 transactions from sequencer batches are properly parsed and included in blocks (test with Sepolia block 0xff tx 0x2)
- [ ] **Verify block hash computation still matches canonical** - Test that header construction with the new ArbOS version defaulting and sequencer coinbase changes produces correct block hashes for early blocks (0x1, 0x10, 0x40) 
- [ ] **End-to-end node testing** - Run the full node sync command and verify transaction counts and hashes match RPC for sample blocks, ensuring no regressions in block advancement or early block correctness
- [ ] **Confirm sequencer coinbase address is correct for Sepolia** - Verify the hardcoded `0xA4B000000000000000000073657175656e636572` matches expected Nitro behavior for Sepolia network

### Notes

- This implements the hypothesis that missing Ethereum typed transactions were causing tx count/hash mismatches
- The `todo!()` branches in `to_compact` need proper implementation before production use
- Changes span multiple repos (tiljrd/reth, tiljrd/arb-alloy integration) so cross-repo compatibility should be verified
- Session requested by @tiljrd
- Link to Devin run: https://app.devin.ai/sessions/7bc5ce5699e946fb8dd21dad9a9a0af6