### PR TITLE
fix: Implement TxHashRef trait for ArbTransactionSigned

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,7 +131,7 @@ dependencies = [
  "arbitrary",
  "auto_impl",
  "c-kzg",
- "derive_more",
+ "derive_more 2.0.1",
  "either",
  "k256",
  "once_cell",
@@ -184,7 +190,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
- "derive_more",
+ "derive_more 2.0.1",
  "itoa",
  "serde",
  "serde_json",
@@ -250,7 +256,7 @@ dependencies = [
  "arbitrary",
  "auto_impl",
  "c-kzg",
- "derive_more",
+ "derive_more 2.0.1",
  "either",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -273,7 +279,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
- "derive_more",
+ "derive_more 2.0.1",
  "op-alloy-consensus",
  "op-revm",
  "revm",
@@ -354,7 +360,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more",
+ "derive_more 2.0.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -415,7 +421,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more",
+ "derive_more 2.0.1",
  "foldhash",
  "getrandom 0.3.3",
  "hashbrown 0.15.5",
@@ -623,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb22d465e02c015648138bc0d46951d267827551fc85922b60f58caa6a0e9c9"
 dependencies = [
  "alloy-primitives",
- "derive_more",
+ "derive_more 2.0.1",
  "serde",
  "serde_with",
 ]
@@ -640,7 +646,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
- "derive_more",
+ "derive_more 2.0.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "jsonwebtoken",
@@ -838,7 +844,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "base64 0.22.1",
- "derive_more",
+ "derive_more 2.0.1",
  "futures",
  "futures-utils-wasm",
  "parking_lot",
@@ -916,7 +922,7 @@ dependencies = [
  "arbitrary",
  "arrayvec",
  "derive_arbitrary",
- "derive_more",
+ "derive_more 2.0.1",
  "nybbles",
  "proptest",
  "proptest-derive",
@@ -1021,6 +1027,67 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "arb-alloy-consensus"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6b781bc9242d4d38df01e1936b0c7af2f6a463200e2401e580727206040351"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "arb-alloy-network"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96157f2af6b7adee519c2fce60b07a79628164410c2b32558ef816018ec748e"
+
+[[package]]
+name = "arb-alloy-predeploys"
+version = "0.1.1"
+dependencies = [
+ "alloy-primitives",
+]
+
+[[package]]
+name = "arb-alloy-predeploys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94abc6fbd063269c1c16ff91e63ffcb6087ae1371b816cd49520de4dacab1338"
+dependencies = [
+ "alloy-primitives",
+]
+
+[[package]]
+name = "arb-alloy-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4194538d8214b5d00881a40eda169d0414bf4c5e69c49930791f10fc8286b4"
+dependencies = [
+ "alloy-primitives",
+]
+
+[[package]]
+name = "arb-reth"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "eyre",
+ "reth-arbitrum-chainspec",
+ "reth-arbitrum-node",
+ "reth-chainspec",
+ "reth-cli",
+ "reth-cli-commands",
+ "reth-cli-runner",
+ "reth-cli-util",
+ "reth-db",
+ "reth-ethereum-cli",
+ "reth-node-builder",
+ "tracing",
 ]
 
 [[package]]
@@ -2428,6 +2495,12 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
@@ -2740,6 +2813,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2895,6 +2974,19 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
@@ -2908,7 +3000,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -3467,7 +3559,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "async-trait",
- "derive_more",
+ "derive_more 2.0.1",
  "eyre",
  "jsonrpsee",
  "modular-bitfield",
@@ -4220,6 +4312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -5319,6 +5412,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libflate"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+dependencies = [
+ "core2",
+ "hashbrown 0.14.5",
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libgit2-sys"
 version = "0.18.2+1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6092,7 +6209,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "arbitrary",
- "derive_more",
+ "derive_more 2.0.1",
  "serde",
  "serde_with",
  "thiserror 2.0.16",
@@ -6143,7 +6260,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "arbitrary",
- "derive_more",
+ "derive_more 2.0.1",
  "op-alloy-consensus",
  "serde",
  "serde_json",
@@ -6163,7 +6280,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-serde",
  "arbitrary",
- "derive_more",
+ "derive_more 2.0.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "op-alloy-consensus",
@@ -7276,6 +7393,238 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-arbitrum-chainspec"
+version = "0.1.0"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-genesis",
+ "alloy-primitives",
+ "anyhow",
+ "base64 0.22.1",
+ "eyre",
+ "libflate",
+ "reth-chainspec",
+ "reth-cli",
+ "reth-primitives-traits",
+ "reth-trie-common",
+ "revm",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "reth-arbitrum-evm"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "arb-alloy-consensus",
+ "arb-alloy-predeploys 0.1.2",
+ "arb-alloy-util",
+ "reth-arbitrum-chainspec",
+ "reth-arbitrum-payload",
+ "reth-arbitrum-primitives",
+ "reth-evm",
+ "reth-evm-ethereum",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-rpc-eth-api",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "revm",
+ "revm-context-interface",
+ "revm-database",
+ "revm-state",
+ "tracing",
+]
+
+[[package]]
+name = "reth-arbitrum-node"
+version = "1.8.1"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "arb-alloy-consensus",
+ "clap",
+ "eyre",
+ "reth-arbitrum-chainspec",
+ "reth-arbitrum-evm",
+ "reth-arbitrum-payload",
+ "reth-arbitrum-primitives",
+ "reth-arbitrum-rpc",
+ "reth-arbitrum-storage",
+ "reth-arbitrum-txpool",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-engine-local",
+ "reth-engine-primitives",
+ "reth-engine-tree",
+ "reth-ethereum-consensus",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-network",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-api",
+ "reth-rpc-engine-api",
+ "reth-rpc-server-types",
+ "reth-storage-api",
+ "reth-tasks",
+ "reth-tracing",
+ "reth-transaction-pool",
+ "reth-trie-common",
+ "reth-trie-db",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "reth-arbitrum-payload"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-engine",
+ "reth-arbitrum-primitives",
+ "reth-basic-payload-builder",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-payload-util",
+ "reth-primitives-traits",
+ "reth-revm",
+ "reth-storage-api",
+ "serde",
+]
+
+[[package]]
+name = "reth-arbitrum-primitives"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "arb-alloy-consensus",
+ "arb-alloy-predeploys 0.1.1",
+ "bytes",
+ "modular-bitfield",
+ "reth-codecs",
+ "reth-primitives-traits",
+ "reth-zstd-compressors",
+ "serde",
+]
+
+[[package]]
+name = "reth-arbitrum-rpc"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "arb-alloy-consensus",
+ "arb-alloy-network",
+ "async-trait",
+ "eyre",
+ "jsonrpsee",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "once_cell",
+ "reth-arbitrum-evm",
+ "reth-arbitrum-payload",
+ "reth-arbitrum-primitives",
+ "reth-chainspec",
+ "reth-engine-primitives",
+ "reth-evm",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-primitives-traits",
+ "reth-rpc",
+ "reth-rpc-api",
+ "reth-rpc-convert",
+ "reth-rpc-engine-api",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-storage-api",
+ "reth-tasks",
+ "reth-transaction-pool",
+ "revm",
+ "revm-context",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-arbitrum-stf-wasm"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+]
+
+[[package]]
+name = "reth-arbitrum-storage"
+version = "1.8.1"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "reth-arbitrum-primitives",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-db-api",
+ "reth-node-api",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-api",
+]
+
+[[package]]
+name = "reth-arbitrum-txpool"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "c-kzg",
+ "derive_more 0.99.20",
+ "reth-arbitrum-primitives",
+ "reth-primitives-traits",
+ "reth-transaction-pool",
+]
+
+[[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.1"
 dependencies = [
@@ -7347,7 +7696,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "codspeed-criterion-compat",
- "derive_more",
+ "derive_more 2.0.1",
  "metrics",
  "parking_lot",
  "pin-project",
@@ -7382,7 +7731,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
- "derive_more",
+ "derive_more 2.0.1",
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -7540,7 +7889,7 @@ dependencies = [
 name = "reth-codecs-derive"
 version = "1.8.1"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "similar-asserts",
@@ -7602,7 +7951,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-transport",
  "auto_impl",
- "derive_more",
+ "derive_more 2.0.1",
  "eyre",
  "futures",
  "reqwest",
@@ -7624,7 +7973,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "codspeed-criterion-compat",
- "derive_more",
+ "derive_more 2.0.1",
  "eyre",
  "metrics",
  "page_size",
@@ -7658,13 +8007,14 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bytes",
- "derive_more",
+ "derive_more 2.0.1",
  "metrics",
  "modular-bitfield",
  "parity-scale-codec",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.9.2",
+ "reth-arbitrum-primitives",
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
@@ -7759,7 +8109,7 @@ version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "derive_more 2.0.1",
  "discv5",
  "enr",
  "futures",
@@ -7860,7 +8210,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
- "derive_more",
+ "derive_more 2.0.1",
  "eyre",
  "futures-util",
  "jsonrpsee",
@@ -8022,7 +8372,7 @@ dependencies = [
  "assert_matches",
  "codspeed-criterion-compat",
  "crossbeam-channel",
- "derive_more",
+ "derive_more 2.0.1",
  "eyre",
  "futures",
  "metrics",
@@ -8194,7 +8544,7 @@ dependencies = [
  "arbitrary",
  "async-stream",
  "bytes",
- "derive_more",
+ "derive_more 2.0.1",
  "futures",
  "pin-project",
  "proptest",
@@ -8233,7 +8583,7 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "bytes",
- "derive_more",
+ "derive_more 2.0.1",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.9.2",
@@ -8394,7 +8744,7 @@ dependencies = [
  "alloy-serde",
  "arbitrary",
  "bincode 1.3.3",
- "derive_more",
+ "derive_more 2.0.1",
  "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",
@@ -8428,7 +8778,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
- "derive_more",
+ "derive_more 2.0.1",
  "futures-util",
  "metrics",
  "reth-ethereum-forks",
@@ -8453,7 +8803,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more",
+ "derive_more 2.0.1",
  "parking_lot",
  "reth-chainspec",
  "reth-ethereum-forks",
@@ -8489,7 +8839,7 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bincode 1.3.3",
- "derive_more",
+ "derive_more 2.0.1",
  "rand 0.9.2",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -8656,7 +9006,7 @@ dependencies = [
  "byteorder",
  "codspeed-criterion-compat",
  "dashmap 6.1.0",
- "derive_more",
+ "derive_more 2.0.1",
  "parking_lot",
  "rand 0.9.2",
  "reth-mdbx-sys",
@@ -8718,7 +9068,7 @@ dependencies = [
  "aquamarine",
  "auto_impl",
  "codspeed-criterion-compat",
- "derive_more",
+ "derive_more 2.0.1",
  "discv5",
  "enr",
  "futures",
@@ -8775,7 +9125,7 @@ dependencies = [
  "alloy-rpc-types-admin",
  "alloy-rpc-types-eth",
  "auto_impl",
- "derive_more",
+ "derive_more 2.0.1",
  "enr",
  "futures",
  "reth-eth-wire-types",
@@ -8798,7 +9148,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "auto_impl",
- "derive_more",
+ "derive_more 2.0.1",
  "futures",
  "parking_lot",
  "reth-consensus",
@@ -8848,7 +9198,7 @@ version = "1.8.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
- "derive_more",
+ "derive_more 2.0.1",
  "lz4_flex",
  "memmap2",
  "rand 0.9.2",
@@ -8931,6 +9281,7 @@ dependencies = [
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
+ "reth-payload-builder-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
@@ -8963,7 +9314,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
- "derive_more",
+ "derive_more 2.0.1",
  "dirs-next",
  "eyre",
  "futures",
@@ -9091,7 +9442,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more",
+ "derive_more 2.0.1",
  "futures",
  "humantime",
  "pin-project",
@@ -9189,7 +9540,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-primitives",
- "derive_more",
+ "derive_more 2.0.1",
  "miniz_oxide",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
@@ -9215,7 +9566,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "clap",
- "derive_more",
+ "derive_more 2.0.1",
  "eyre",
  "futures-util",
  "op-alloy-consensus",
@@ -9430,7 +9781,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "derive_more",
+ "derive_more 2.0.1",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "reth-basic-payload-builder",
@@ -9500,7 +9851,7 @@ dependencies = [
  "alloy-transport",
  "alloy-transport-http",
  "async-trait",
- "derive_more",
+ "derive_more 2.0.1",
  "eyre",
  "futures",
  "jsonrpsee",
@@ -9571,7 +9922,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "c-kzg",
- "derive_more",
+ "derive_more 2.0.1",
  "futures-util",
  "metrics",
  "op-alloy-consensus",
@@ -9703,7 +10054,7 @@ dependencies = [
  "bincode 1.3.3",
  "byteorder",
  "bytes",
- "derive_more",
+ "derive_more 2.0.1",
  "modular-bitfield",
  "once_cell",
  "op-alloy-consensus",
@@ -9813,7 +10164,7 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "assert_matches",
- "derive_more",
+ "derive_more 2.0.1",
  "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",
@@ -9917,7 +10268,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
- "derive_more",
+ "derive_more 2.0.1",
  "dyn-clone",
  "futures",
  "http",
@@ -10085,6 +10436,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
+ "arb-alloy-network",
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
@@ -10092,6 +10444,7 @@ dependencies = [
  "op-alloy-network",
  "op-alloy-rpc-types",
  "op-revm",
+ "reth-arbitrum-primitives",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-optimism-primitives",
@@ -10214,7 +10567,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
- "derive_more",
+ "derive_more 2.0.1",
  "futures",
  "itertools 0.14.0",
  "jsonrpsee-core",
@@ -10437,7 +10790,7 @@ version = "1.8.1"
 dependencies = [
  "alloy-primitives",
  "clap",
- "derive_more",
+ "derive_more 2.0.1",
  "reth-nippy-jar",
  "serde",
  "strum 0.27.2",
@@ -10472,7 +10825,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "derive_more 2.0.1",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
@@ -10673,7 +11026,7 @@ dependencies = [
  "bincode 1.3.3",
  "bytes",
  "codspeed-criterion-compat",
- "derive_more",
+ "derive_more 2.0.1",
  "hash-db",
  "itertools 0.14.0",
  "nybbles",
@@ -10722,7 +11075,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "codspeed-criterion-compat",
- "derive_more",
+ "derive_more 2.0.1",
  "itertools 0.14.0",
  "metrics",
  "proptest",
@@ -11061,6 +11414,12 @@ checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rlimit"

--- a/crates/arbitrum/primitives/src/lib.rs
+++ b/crates/arbitrum/primitives/src/lib.rs
@@ -11,7 +11,7 @@ use alloy_consensus::{
 use alloy_eips::eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718};
 use alloy_primitives::{keccak256, Address, Bytes, Signature, TxHash, TxKind, U256, B256};
 use alloy_rlp::{Decodable, Encodable, Header};
-use alloy_consensus::transaction::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx};
+use alloy_consensus::transaction::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx, TxHashRef};
 
 use core::hash::{Hash, Hasher};
 use core::ops::Deref;
@@ -779,9 +779,15 @@ impl alloy_consensus::transaction::SignerRecoverable for ArbTransactionSigned {
 }
 
 
-impl SignedTransaction for ArbTransactionSigned {
+impl alloy_consensus::transaction::TxHashRef for ArbTransactionSigned {
     fn tx_hash(&self) -> &TxHash {
         self.hash.get_or_init(|| self.recalculate_hash())
+    }
+}
+
+impl SignedTransaction for ArbTransactionSigned {
+    fn recalculate_hash(&self) -> B256 {
+        alloy_primitives::keccak256(self.encoded_2718())
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes compilation errors in the Arbitrum primitives by properly implementing the `TxHashRef` trait for `ArbTransactionSigned`. This is required for compatibility with the latest alloy-consensus API changes.

## Changes

### TxHashRef Trait Implementation
- Implemented `alloy_consensus::transaction::TxHashRef` for `ArbTransactionSigned`
- Added `TxHashRef` to imports to make `tx_hash()` method available in all contexts
- Split `SignedTransaction` implementation to properly separate `recalculate_hash()` method

### Technical Details

The issue was that `ArbTransactionSigned` was implementing a `tx_hash()` method through the `SignedTransaction` trait, but the alloy ecosystem now expects the `TxHashRef` trait for accessing transaction hashes. This caused compilation errors in contexts where `tx_hash()` was called but the `TxHashRef` trait wasn't in scope.

**Before:**
```rust
impl SignedTransaction for ArbTransactionSigned {
    fn tx_hash(&self) -> &TxHash {
        self.hash.get_or_init(|| self.recalculate_hash())
    }
}
```

**After:**
```rust
impl alloy_consensus::transaction::TxHashRef for ArbTransactionSigned {
    fn tx_hash(&self) -> &TxHash {
        self.hash.get_or_init(|| self.recalculate_hash())
    }
}

impl SignedTransaction for ArbTransactionSigned {
    fn recalculate_hash(&self) -> B256 {
        alloy_primitives::keccak256(self.encoded_2718())
    }
}
```

### Files Modified
- `crates/arbitrum/primitives/src/lib.rs`: Added `TxHashRef` trait implementation and import

## Testing

The changes enable `reth-arbitrum-primitives` to compile successfully. The implementation follows the same pattern used in Optimism primitives.

## Related Changes

This PR complements tiljrd/nitro-rs#31 which adds CLI parameter support for running nitro-rs as an Arbitrum Sepolia follower node.

---

**Link to Devin run:** https://app.devin.ai/sessions/fdf88a883f894e7981a90931e99879d3

**Requested by:** Til Jordan (til@bloctopus.io) (@tiljrd)